### PR TITLE
Kill badly terminated old vnc session before vnc starts and fix gtk initialization failed

### DIFF
--- a/vnc-version/Dockerfile
+++ b/vnc-version/Dockerfile
@@ -87,8 +87,9 @@ RUN printf '%s\n' \
 'xterm &' > ~/.vnc/xstartup
 
 # this won't work if you have 99 monitors, 98 monitors is fine though
-RUN printf '%s\n%s\n\n' \
+RUN printf '%s\n%s\n%s\n\n' \
 'export DISPLAY=:99' \
+'vncserver -kill :99 || true' \
 'vncserver -geometry 1920x1080 -depth ${DEPTH:=24} -xstartup ~/.vnc/xstartup :99' > vnc.sh
 
 RUN cat vnc.sh OpenCore-Boot.sh > OpenCore-Boot_custom.sh


### PR DESCRIPTION
When you run the VNC version [blob/master/vnc-version/Dockerfile](https://github.com/sickcodes/Docker-OSX/blob/master/vnc-version/Dockerfile) and you stop/restart the container as:

```
docker stop <container ID>
docker start <container ID>
```

Then it fails with:

```
gtk initialization failed
```

This happens when when qemu tries to start. The problem is that the `vncserver` command in `OpenCore-Boot_custom.sh` fails with (but does not terminate the bash script) with the following error:

```
Warning: f21471f8a08f:99 is taken because of /tmp/.X99-lock
Remove this file if there is no X server f21471f8a08f:99
A VNC server is already running as :99
```

Adding `vncserver -kill :99 || true` before `vncserver` fixes the issue.
