### PR TITLE
Skip downloading huge files that are not needed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ WORKDIR /home/arch/gibMacOS
 RUN perl -p -i -e 's/print("Succeeded:")/exit()/' ./gibMacOS.command
 
 # this command takes a while!
-RUN python gibMacOS.command -v "${VERSION}" || echo Done
+RUN python gibMacOS.command -v "${VERSION}" -d || echo Done
 
 RUN sudo pacman -S qemu libvirt dnsmasq virt-manager bridge-utils flex bison ebtables edk2-ovmf --noconfirm
 # RUN sudo systemctl enable libvirtd.service


### PR DESCRIPTION
Only `BaseSystem.dmg` should be downloaded. But it started to download huge 5GB file while building.

Ref:
https://github.com/corpnewt/gibMacOS/blob/58b48b63dbeeab21994b6cc6a4480ac2bc54b227/gibMacOS.command#L533