### PR TITLE
Document how to make firewalld work on Fedora with bridged networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,15 @@ sudo nohup dockerd &
 
 ```
 
+If you have no internet connectivity from the VM, you are using bridge
+networking, and you are running Fedora:
+
+```
+# Set the docker0 bridge to the trusted zone
+sudo firewall-cmd --permanent --zone=trusted --add-interface=docker0
+sudo firewall-cmd --reload
+```
+
 # Backup the disk
 
 your image will be stored in:


### PR DESCRIPTION
`firewalld` doesn't allow DNS requests (this is the case that bit me,
but there might be more) on `docker0` unless the interface is added to
the trusted zone.

See: https://github.com/docker/for-linux/issues/955
Fixes: https://github.com/sickcodes/Docker-OSX/issues/56
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>