### PR TITLE
Fix gpk error

### DIFF
--- a/vnc-version/Dockerfile
+++ b/vnc-version/Dockerfile
@@ -98,8 +98,9 @@ RUN printf '%s\n' \
 'xinit &' \
 'xterm &' > ~/.vnc/xstartup
 
-# this won't work if you have 99 monitors, 98 monitors is fine though
+# this won't work if you have 99 monitors, 98 monitors is fine though // don't forget to remove the lock file incase you shut down incorrectly or create an image.
 RUN printf '%s\n%s\n%s\n\n' \
+'sudo rm -rf /tmp/.X99-lock' \
 'export DISPLAY=:99' \
 'vncserver -kill :99 || true' \
 'vncserver -geometry 1920x1080 -depth ${DEPTH} -xstartup ~/.vnc/xstartup :99' > vnc.sh

--- a/vnc-version/Dockerfile
+++ b/vnc-version/Dockerfile
@@ -99,7 +99,7 @@ RUN printf '%s\n' \
 'xterm &' > ~/.vnc/xstartup
 
 # this won't work if you have 99 monitors, 98 monitors is fine though // don't forget to remove the lock file incase you shut down incorrectly or create an image.
-RUN printf '%s\n%s\n%s\n\n' \
+RUN printf '%s\n%s\n%s\n%s\n\n' \
 'sudo rm -f /tmp/.X99-lock' \
 'export DISPLAY=:99' \
 'vncserver -kill :99 || true' \

--- a/vnc-version/Dockerfile
+++ b/vnc-version/Dockerfile
@@ -100,7 +100,7 @@ RUN printf '%s\n' \
 
 # this won't work if you have 99 monitors, 98 monitors is fine though // don't forget to remove the lock file incase you shut down incorrectly or create an image.
 RUN printf '%s\n%s\n%s\n\n' \
-'sudo rm -rf /tmp/.X99-lock' \
+'sudo rm -f /tmp/.X99-lock' \
 'export DISPLAY=:99' \
 'vncserver -kill :99 || true' \
 'vncserver -geometry 1920x1080 -depth ${DEPTH} -xstartup ~/.vnc/xstartup :99' > vnc.sh


### PR DESCRIPTION
Fix gpk error caused by imaging or improper shutdown by removing the `/tmp/.X99-lock` file before starting VNC