### PR TITLE
[Issue] Tigervnc version downgrade to 1.10.0

### DIFF
--- a/vnc-version/Dockerfile
+++ b/vnc-version/Dockerfile
@@ -88,9 +88,10 @@ RUN tee -a /etc/pacman.d/mirrorlist <<< 'Server = https://mirror.rackspace.com/a
 # rankmirrors -n 5 - > /etc/pacman.d/mirrorlist
 
 USER arch
+RUN sudo pacman -U https://archive.archlinux.org/packages/t/tigervnc/tigervnc-1.10.1-2-x86_64.pkg.tar.zst --noconfirm
 
 RUN sudo pacman -Sy --noconfirm
-RUN sudo pacman -S tigervnc xterm xorg-xhost xdotool ufw --noconfirm
+RUN sudo pacman -S xterm xorg-xhost xorg-xinit xdotool ufw --noconfirm
 
 RUN mkdir ${HOME}/.vnc
 

--- a/vnc-version/Dockerfile
+++ b/vnc-version/Dockerfile
@@ -93,7 +93,7 @@ ARG TIGERVNC_VERSION=1.10.1-2
 RUN sudo pacman -U https://archive.archlinux.org/packages/t/tigervnc/tigervnc-${TIGERVNC_VERSION}-x86_64.pkg.tar.zst --noconfirm
 
 RUN sudo pacman -Sy --noconfirm
-RUN sudo pacman -S xterm xorg-xhost xorg-xinit xdotool ufw --noconfirm
+RUN sudo pacman -S xterm xorg-xhost xdotool ufw --noconfirm
 
 RUN mkdir ${HOME}/.vnc
 

--- a/vnc-version/Dockerfile
+++ b/vnc-version/Dockerfile
@@ -88,7 +88,9 @@ RUN tee -a /etc/pacman.d/mirrorlist <<< 'Server = https://mirror.rackspace.com/a
 # rankmirrors -n 5 - > /etc/pacman.d/mirrorlist
 
 USER arch
-RUN sudo pacman -U https://archive.archlinux.org/packages/t/tigervnc/tigervnc-1.10.1-2-x86_64.pkg.tar.zst --noconfirm
+
+ARG TIGERVNC_VERSION=1.10.1-2
+RUN sudo pacman -U https://archive.archlinux.org/packages/t/tigervnc/tigervnc-${TIGERVNC_VERSION}-x86_64.pkg.tar.zst --noconfirm
 
 RUN sudo pacman -Sy --noconfirm
 RUN sudo pacman -S xterm xorg-xhost xorg-xinit xdotool ufw --noconfirm


### PR DESCRIPTION
When build the vnc version, archlinux will install  tigervnc 1.11.0-x

https://www.archlinux.org/packages/community/x86_64/tigervnc/

Currently, 1.11.0 is beta version and I got some errors when create a container from built image:

```sh
Unable to init server: Could not connect: Connection refused
QEMU 5.1.0 monitor - type 'help' for more information
ALSA lib confmisc.c:767:(parse_card) cannot find card '0'
ALSA lib conf.c:4743:(_snd_config_evaluate) function snd_func_card_driver returned error: No such file or directory
ALSA lib confmisc.c:392:(snd_func_concat) error evaluating strings
ALSA lib conf.c:4743:(_snd_config_evaluate) function snd_func_concat returned error: No such file or directory
........
alsa: Could not initialize ADC
alsa: Failed to open `default':
alsa: Reason: No such file or directory
audio: Failed to create voice `adc'
gtk initialization failed
```

or

```sh
Couldn't find suitable Xsession
```

---

I decide to downgrade tigervnc to stable version 1.10.0 and it's working again.