### PR TITLE
misc improvements to build, runtime and documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,7 @@ RUN tee -a /etc/pacman.conf <<< '[community-testing]' \
 
 RUN pacman -Syu --noconfirm \
     && pacman -S sudo git make automake gcc python go autoconf cmake pkgconf alsa-utils fakeroot --noconfirm \
+    && yes | pacman -Scc \
     && useradd arch -p arch \
     && tee -a /etc/sudoers <<< 'arch ALL=(ALL) NOPASSWD: ALL' \
     && mkdir /home/arch \
@@ -106,7 +107,7 @@ RUN perl -p -i -e 's/print("Succeeded:")/exit()/' ./gibMacOS.command
 # this command takes a while!
 RUN python gibMacOS.command -v "${VERSION}" -d || echo Done
 
-RUN sudo pacman -Syu qemu libvirt dnsmasq virt-manager bridge-utils flex bison ebtables edk2-ovmf netctl libvirt-dbus libguestfs --noconfirm
+RUN sudo pacman -Syu qemu libvirt dnsmasq virt-manager bridge-utils flex bison ebtables edk2-ovmf netctl libvirt-dbus libguestfs --noconfirm && yes | pacman -Scc
 # RUN sudo systemctl enable libvirtd.service
 # RUN sudo systemctl enable virtlogd.service
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -156,7 +156,7 @@ RUN touch Launch.sh \
     && tee -a Launch.sh <<< '-drive if=pflash,format=raw,readonly,file=/home/arch/OSX-KVM/OVMF_CODE.fd \' \
     && tee -a Launch.sh <<< '-drive if=pflash,format=raw,file=./OVMF_VARS-1024x768.fd \' \
     && tee -a Launch.sh <<< '-smbios type=2 \' \
-    && tee -a Launch.sh <<< '-device ich9-intel-hda -device hda-duplex \' \
+    && tee -a Launch.sh <<< '-audiodev ${AUDIO_DRIVER:-alsa},id=hda -device ich9-intel-hda -device hda-duplex,audiodev=hda \' \
     && tee -a Launch.sh <<< '-device ich9-ahci,id=sata \' \
     && tee -a Launch.sh <<< '-drive id=OpenCoreBoot,if=none,snapshot=on,format=qcow2,file=/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2 \' \
     && tee -a Launch.sh <<< '-device ide-hd,bus=sata.2,drive=OpenCoreBoot \' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -169,6 +169,8 @@ RUN touch Launch.sh \
 
 ENV USER arch
 
+ENV DISPLAY=:0.0
+
 USER arch
 VOLUME ["/tmp/.X11-unix"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,9 +145,9 @@ RUN touch Launch.sh \
     && chmod +x ./Launch.sh \
     && tee -a Launch.sh <<< '#!/bin/sh' \
     && tee -a Launch.sh <<< 'set -eu' \
-    && tee -a Launch.sh <<< 'exec qemu-system-x86_64 -enable-kvm -m ${RAM:-8}000 \' \
-    && tee -a Launch.sh <<< '-cpu Penryn,kvm=on,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+pcid,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check \' \
-    && tee -a Launch.sh <<< '-machine q35 \' \
+    && tee -a Launch.sh <<< 'exec qemu-system-x86_64 -m ${RAM:-8}000 \' \
+    && tee -a Launch.sh <<< '-cpu Penryn,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+pcid,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check \' \
+    && tee -a Launch.sh <<< '-machine q35,accel=kvm:tcg \' \
     && tee -a Launch.sh <<< '-smp ${SMP:-4},cores=${CORES:-4} \' \
     && tee -a Launch.sh <<< '-usb -device usb-kbd -device usb-tablet \' \
     && tee -a Launch.sh <<< '-device isa-applesmc,osk=ourhardworkbythesewordsguardedpleasedontsteal\(c\)AppleComputerInc \' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -143,10 +143,10 @@ RUN touch enable-ssh.sh \
 
 RUN touch Launch.sh \
     && chmod +x ./Launch.sh \
-    && tee -a Launch.sh <<< 'qemu-system-x86_64 -enable-kvm -m ${RAM}000 \' \
+    && tee -a Launch.sh <<< 'qemu-system-x86_64 -enable-kvm -m ${RAM:-8}000 \' \
     && tee -a Launch.sh <<< '-cpu Penryn,kvm=on,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+pcid,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check \' \
     && tee -a Launch.sh <<< '-machine q35 \' \
-    && tee -a Launch.sh <<< '-smp ${SMP},cores=${CORES} \' \
+    && tee -a Launch.sh <<< '-smp ${SMP:-4},cores=${CORES:-4} \' \
     && tee -a Launch.sh <<< '-usb -device usb-kbd -device usb-tablet \' \
     && tee -a Launch.sh <<< '-device isa-applesmc,osk=ourhardworkbythesewordsguardedpleasedontsteal\(c\)AppleComputerInc \' \
     && tee -a Launch.sh <<< '-drive if=pflash,format=raw,readonly,file=/home/arch/OSX-KVM/OVMF_CODE.fd \' \
@@ -160,27 +160,12 @@ RUN touch Launch.sh \
     && tee -a Launch.sh <<< '-drive id=InstallMedia,if=none,file=BaseSystem.img,format=raw \' \
     && tee -a Launch.sh <<< '-drive id=MacHDD,if=none,file=/home/arch/OSX-KVM/mac_hdd_ng.img,format=qcow2 \' \
     && tee -a Launch.sh <<< '-device ide-hd,bus=sata.4,drive=MacHDD \' \
-    && tee -a Launch.sh <<< '-netdev user,id=net0,hostfwd=tcp::${INTERNAL_SSH_PORT}-:22,hostfwd=tcp::${SCREEN_SHARE_PORT}-:5900, -device e1000-82545em,netdev=net0,id=net0,mac=52:54:00:09:49:17 \' \
+    && tee -a Launch.sh <<< '-netdev user,id=net0,hostfwd=tcp::${INTERNAL_SSH_PORT:-10022}-:22,hostfwd=tcp::${SCREEN_SHARE_PORT:-5900}-:5900, -device e1000-82545em,netdev=net0,id=net0,mac=52:54:00:09:49:17 \' \
     && tee -a Launch.sh <<< '-monitor stdio \' \
     && tee -a Launch.sh <<< '-vga vmware \' \
-    && tee -a Launch.sh <<< '${EXTRA}'
+    && tee -a Launch.sh <<< '${EXTRA:-}'
 
 ENV USER arch
-
-ENV RAM=8
-ENV SMP=4
-ENV CORES=4
-ENV EXTRA=
-ENV INTERNAL_SSH_PORT=10022
-ENV SCREEN_SHARE_PORT=5900
-
-# if you're in the shell, export these variables to use then in envsubst
-# export RAM=5
-# export SMP=4
-# export CORES=4
-# export EXTRA=
-# export INTERNAL_SSH_PORT=10022
-# export SCREEN_SHARE_PORT=5900
 
 USER arch
 VOLUME ["/tmp/.X11-unix"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -143,7 +143,9 @@ RUN touch enable-ssh.sh \
 
 RUN touch Launch.sh \
     && chmod +x ./Launch.sh \
-    && tee -a Launch.sh <<< 'qemu-system-x86_64 -enable-kvm -m ${RAM:-8}000 \' \
+    && tee -a Launch.sh <<< '#!/bin/sh' \
+    && tee -a Launch.sh <<< 'set -eu' \
+    && tee -a Launch.sh <<< 'exec qemu-system-x86_64 -enable-kvm -m ${RAM:-8}000 \' \
     && tee -a Launch.sh <<< '-cpu Penryn,kvm=on,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+pcid,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check \' \
     && tee -a Launch.sh <<< '-machine q35 \' \
     && tee -a Launch.sh <<< '-smp ${SMP:-4},cores=${CORES:-4} \' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,6 +145,8 @@ RUN touch Launch.sh \
     && chmod +x ./Launch.sh \
     && tee -a Launch.sh <<< '#!/bin/sh' \
     && tee -a Launch.sh <<< 'set -eu' \
+    && tee -a Launch.sh <<< 'sudo chown    $(id -u):$(id -g) /dev/kvm 2>/dev/null || true' \
+    && tee -a Launch.sh <<< 'sudo chown -R $(id -u):$(id -g) /dev/snd 2>/dev/null || true' \
     && tee -a Launch.sh <<< 'exec qemu-system-x86_64 -m ${RAM:-8}000 \' \
     && tee -a Launch.sh <<< '-cpu Penryn,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+pcid,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check \' \
     && tee -a Launch.sh <<< '-machine q35,accel=kvm:tcg \' \

--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ xhost +
 docker run --device /dev/kvm --device /dev/snd -v /tmp/.X11-unix:/tmp/.X11-unix sickcodes/docker-osx ./OpenCore-Boot.sh
 ```
 
+PulseAudio for sound (note neither [AppleALC](https://github.com/acidanthera/AppleALC) and varying [`alcid`](https://dortania.github.io/OpenCore-Post-Install/universal/audio.html) or [VoodooHDA-OC](https://github.com/chris1111/VoodooHDA-OC) have [codec support](https://osy.gitbook.io/hac-mini-guide/details/hda-fix#hda-codec) though [IORegistryExplorer](https://github.com/vulgo/IORegistryExplorer) does show the controller component working):
+```bash
+docker run --device /dev/kvm -e AUDIO_DRIVER=pa,server=unix:/tmp/pulseaudio.socket -v /run/user/$(id -u)/pulse/native:/tmp/pulseaudio.socket -v /tmp/.X11-unix:/tmp/.X11-unix sickcodes/docker-osx
+```
+PulseAudio debugging:
+```bash
+docker run --device /dev/kvm -e AUDIO_DRIVER=pa,server=unix:/tmp/pulseaudio.socket -v /run/user/$(id -u)/pulse/native:/tmp/pulseaudio.socket -v /tmp/.X11-unix:/tmp/.X11-unix -e PULSE_SERVER=unix:/tmp/pulseaudio.socket sickcodes/docker-osx pactl list
+```
+
 Alternative run, thanks @roryrjb
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Pull requests, suggestions very welcome!
 
 docker pull sickcodes/docker-osx
 
-docker run --privileged -v /tmp/.X11-unix:/tmp/.X11-unix sickcodes/docker-osx
+docker run --device /dev/kvm --device /dev/snd -v /tmp/.X11-unix:/tmp/.X11-unix sickcodes/docker-osx
 
 # press ctrl G if your mouse gets stuck
 
@@ -40,7 +40,7 @@ docker run --privileged -v /tmp/.X11-unix:/tmp/.X11-unix sickcodes/docker-osx
 
 # need more RAM and SSH on 0.0.0.0:50922?
 
-docker run -e RAM=4 -p 50922:10022 --privileged -v /tmp/.X11-unix:/tmp/.X11-unix sickcodes/docker-osx:latest
+docker run --device /dev/kvm --device /dev/snd -e RAM=4 -p 50922:10022 sickcodes/docker-osx:latest
 
 ssh fullname@localhost -p 50922
 
@@ -109,7 +109,7 @@ docker ps --all #make note of your container id
 docker commit containerID newImageName
 
 # To run this image do the following
-docker run --privileged -v /tmp/.X11-unix:/tmp/.X11-unix newImageName
+docker run --device /dev/kvm --device /dev/snd -v /tmp/.X11-unix:/tmp/.X11-unix newImageName
 ```
 
 # Troubleshooting
@@ -130,7 +130,7 @@ sudo yum install xorg-x11-server-utils
 # then run
 xhost +
 
-docker run --privileged -v /tmp/.X11-unix:/tmp/.X11-unix sickcodes/docker-osx ./OpenCore-Boot.sh
+docker run --device /dev/kvm --device /dev/snd -v /tmp/.X11-unix:/tmp/.X11-unix sickcodes/docker-osx ./OpenCore-Boot.sh
 ```
 
 Alternative run, thanks @roryrjb
@@ -157,12 +157,6 @@ Turn on docker daemon
 sudo dockerd
 # or daemonize it
 sudo nohup dockerd &
-```
-
-Check /dev/kvm permissions
-
-```bash
-sudo chmod 666 /dev/kvm
 ```
 
 If you don't have Docker already
@@ -261,7 +255,7 @@ docker run \
 -e CORES=4 \
 -e EXTRA='-usb -device usb-host,hostbus=1,hostaddr=8' \
 -e INTERNAL_SSH_PORT=23 \
---privileged -v /tmp/.X11-unix:/tmp/.X11-unix docker-osx:latest
+--device /dev/kvm --device /dev/snd -v /tmp/.X11-unix:/tmp/.X11-unix docker-osx:latest
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Pull requests, suggestions very welcome!
 
 docker pull sickcodes/docker-osx
 
-docker run --privileged -e "DISPLAY=${DISPLAY:-:0.0}" -v /tmp/.X11-unix:/tmp/.X11-unix sickcodes/docker-osx
+docker run --privileged -v /tmp/.X11-unix:/tmp/.X11-unix sickcodes/docker-osx
 
 # press ctrl G if your mouse gets stuck
 
@@ -40,7 +40,7 @@ docker run --privileged -e "DISPLAY=${DISPLAY:-:0.0}" -v /tmp/.X11-unix:/tmp/.X1
 
 # need more RAM and SSH on 0.0.0.0:50922?
 
-docker run -e RAM=4 -p 50922:10022 --privileged -e "DISPLAY=${DISPLAY:-:0.0}" -v /tmp/.X11-unix:/tmp/.X11-unix sickcodes/docker-osx:latest
+docker run -e RAM=4 -p 50922:10022 --privileged -v /tmp/.X11-unix:/tmp/.X11-unix sickcodes/docker-osx:latest
 
 ssh fullname@localhost -p 50922
 
@@ -109,7 +109,7 @@ docker ps --all #make note of your container id
 docker commit containerID newImageName
 
 # To run this image do the following
-docker run --privileged -e "DISPLAY=${DISPLAY:-:0.0}" -v /tmp/.X11-unix:/tmp/.X11-unix newImageName
+docker run --privileged -v /tmp/.X11-unix:/tmp/.X11-unix newImageName
 ```
 
 # Troubleshooting
@@ -130,7 +130,7 @@ sudo yum install xorg-x11-server-utils
 # then run
 xhost +
 
-docker run --privileged -e "DISPLAY=${DISPLAY:-:0.0}" -v /tmp/.X11-unix:/tmp/.X11-unix sickcodes/docker-osx ./OpenCore-Boot.sh
+docker run --privileged -v /tmp/.X11-unix:/tmp/.X11-unix sickcodes/docker-osx ./OpenCore-Boot.sh
 ```
 
 Alternative run, thanks @roryrjb


### PR DESCRIPTION
Several proposed improvements:

 * remove the need for `privileged`
 * reduce final image by ~2.5GB (from 6GB)
 * support fallback from kvm to tcg
 * use shell expansions and push `DISPLAY` into `ENV` so it does not need to be supplied
 * provide example on how to use PulseAudio
     * partly resolves https://github.com/sickcodes/Docker-OSX/issues/71
     * note that due to (seemingly) the lack of codec driver support there still is no audio support in the guest

