### PR TITLE
modify/auto-boot vnc container

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ docker ps
 # NEW CONTAINERS
 docker exec containerID mv ./Launch-nopicker.sh ./Launch.sh
 
+# VNC-VERSION-CONTAINER
+docker exec containerID mv ./Launch-nopicker.sh ./Launch_custom.sh
+
 # LEGACY CONTAINERS
 docker exec containerID bash -c "grep -v InstallMedia ./Launch.sh > ./Launch-nopicker.sh
 chmod +x ./Launch-nopicker.sh


### PR DESCRIPTION
## What?
Modified to autoboot for vnc-version container in `README.md` file for better usability. For more background, see ticket #83 .

## Why?
Because the script provided in the readme file didn't work on vnc-version container.

## How?
instead of targeting Launch.sh file, change it to Launch_custom.sh.
```bash
docker exec containerID mv ./Launch-nopicker.sh ./Launch_custom.sh

```
## Testing?
No automated tests, take my word for it ;)
 
## Screenshots
**Before**
![image](https://user-images.githubusercontent.com/55929982/98357198-26194080-2025-11eb-81bb-28259a1f63ab.png)

**After**
![mac_nopicker](https://user-images.githubusercontent.com/55929982/98367449-f0308800-2035-11eb-9e4e-26b9f0d75f3c.png)

## Anything Else?
Nope