### PR TITLE
Reduce image size by setting git clone depth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ USER arch
 
 # download OSX-KVM
 WORKDIR /home/arch
-RUN git clone https://github.com/kholia/OSX-KVM.git
+RUN git clone --depth 1 https://github.com/kholia/OSX-KVM.git
 
 # enable ssh
 # docker exec .... ./enable-ssh.sh
@@ -128,7 +128,7 @@ RUN sudo pacman -Syu qemu libvirt dnsmasq virt-manager bridge-utils flex bison e
 
 WORKDIR /home/arch/OSX-KVM
 
-RUN git clone https://github.com/corpnewt/gibMacOS.git
+RUN git clone --depth 1 https://github.com/corpnewt/gibMacOS.git
 
 WORKDIR /home/arch/OSX-KVM/gibMacOS
 


### PR DESCRIPTION
Reduce the `git clone` depth to 1 will make the image size smaller, for more than 100MB!

```
$ docker images
REPOSITORY                    TAG                 IMAGE ID            CREATED             SIZE
docker-osx-new                latest              35f286bfee15        1 minutes ago       3.32GB
docker-osx-old                latest              e476cc91939f        9 minutes ago       3.44GB
```