### PR TITLE
Improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,8 @@ FROM archlinux:latest
 
 MAINTAINER 'https://sick.codes' <https://sick.codes>
 
+SHELL ["/bin/bash", "-c"]
+
 # change disk size here or add during build, e.g. --build-arg VERSION=10.14.5 --build-arg SIZE=50G
 ARG SIZE=200G
 ARG VERSION=10.15.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN tee -a /etc/pacman.conf <<< '[community-testing]' \
     && tee -a /etc/pacman.conf <<< 'Include = /etc/pacman.d/mirrorlist'
 
 RUN pacman -Syu --noconfirm \
-    && pacman -S sudo git make automake gcc python go autoconf cmake pkgconf alsa-utils fakeroot vim nano --noconfirm \
+    && pacman -S sudo git vim nano --noconfirm \
     && yes | pacman -Scc \
     && ln -s /bin/vim /bin/vi \
     && useradd arch -p arch \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,40 @@
 #!/usr/bin/docker
 #     ____             __             ____  ______  __
 #    / __ \____  _____/ /_____  _____/ __ \/ ___/ |/ /
-#   / / / / __ \/ ___/ //_/ _ \/ ___/ / / /\__ \|   / 
-#  / /_/ / /_/ / /__/ ,< /  __/ /  / /_/ /___/ /   |  
-# /_____/\____/\___/_/|_|\___/_/   \____//____/_/|_|  
-# 
+#   / / / / __ \/ ___/ //_/ _ \/ ___/ / / /\__ \|   /
+#  / /_/ / /_/ / /__/ ,< /  __/ /  / /_/ /___/ /   |
+# /_____/\____/\___/_/|_|\___/_/   \____//____/_/|_|
+#
 # Repo:             https://github.com/sickcodes/Docker-OSX/
 # Title:            Mac on Docker (Docker-OSX)
-# Author:           Sick.Codes https://sick.codes/ 
+# Author:           Sick.Codes https://sick.codes/
 # Version:          2.6
 # License:          GPLv3+
-# 
+#
 # All credits for OSX-KVM and the rest at @Kholia's repo: https://github.com/kholia/osx-kvm
-# OpenCore support go to https://github.com/Leoyzen/KVM-Opencore 
+# OpenCore support go to https://github.com/Leoyzen/KVM-Opencore
 # and https://github.com/thenickdude/KVM-Opencore/
-# 
+#
 # This Dockerfile automates the installation of Docker-OSX
 # It will build a 200GB container. You can change the size using build arguments.
 # This Dockerfile builds on top of the work done by Dhiru Kholia, and many others.
-#       
+#
 # Build:
 #
 #       docker build -t docker-osx .
 #       docker build -t docker-osx --build-arg VERSION=10.15.5 --build-arg SIZE=200G .
-#       
+#
 # Basic Run:
-#       
+#
 #       docker run --device /dev/kvm --device /dev/snd -v /tmp/.X11-unix:/tmp/.X11-unix -e "DISPLAY=${DISPLAY:-:0.0}" sickcodes/docker-osx:latest
 #
-#
 # Run with SSH:
-# 
-# 
+#
 #       docker run --device /dev/kvm --device /dev/snd -e RAM=6 -p 50922:10022 -v /tmp/.X11-unix:/tmp/.X11-unix -e "DISPLAY=${DISPLAY:-:0.0}" sickcodes/docker-osx:latest
 #       # ssh fullname@localhost -p 50922
-# 
+#
 # Optargs:
-#       
+#
 #       SIZE=200G
 #       VERSION=10.15.6
 #       ENV RAM=5
@@ -49,7 +47,6 @@
 #
 #       docker run ... -e EXTRA="-usb -device usb-host,hostbus=1,hostaddr=8" ...
 #       # you will also need to pass the device to the container
-#
 
 FROM archlinux:latest
 
@@ -130,10 +127,10 @@ WORKDIR /home/arch/OSX-KVM/gibMacOS
 
 # this command takes a while!
 RUN perl -p -i -e 's/print("Succeeded:")/exit()/' ./gibMacOS.command \
-	&& { python gibMacOS.command -v "${VERSION}" -d || echo Done; } \
-	&& qemu-img convert /home/arch/OSX-KVM/gibMacOS/macOS\ Downloads/publicrelease/*/BaseSystem.dmg -O qcow2 -p -c /home/arch/OSX-KVM/BaseSystem.img \
-	&& qemu-img create -f qcow2 /home/arch/OSX-KVM/mac_hdd_ng.img "${SIZE}" \
-	&& rm /home/arch/OSX-KVM/gibMacOS/macOS\ Downloads/publicrelease/*/BaseSystem.dmg
+    && { python gibMacOS.command -v "${VERSION}" -d || echo Done; } \
+    && qemu-img convert /home/arch/OSX-KVM/gibMacOS/macOS\ Downloads/publicrelease/*/BaseSystem.dmg -O qcow2 -p -c /home/arch/OSX-KVM/BaseSystem.img \
+    && qemu-img create -f qcow2 /home/arch/OSX-KVM/mac_hdd_ng.img "${SIZE}" \
+    && rm /home/arch/OSX-KVM/gibMacOS/macOS\ Downloads/publicrelease/*/BaseSystem.dmg
 
 # > Launch.sh
 # > Docker-OSX.xml


### PR DESCRIPTION
1. Set the shell to bash is more proper for current instructions in the Dockerfile.
2. Removal of the unused packages save the size a lot.

```
$ docker images
REPOSITORY                    TAG                 IMAGE ID            CREATED             SIZE
docker-osx                    newone              747ac72ebc3f        4 days ago          2.52GB
docker-osx                    oldone              81c8272d3156        4 days ago          3.28GB
```

3. Adjust the spaces/indents and empty lines in Dockefile

See the commit message for more details! (feel free to ping me if it's not enough)