### PR TITLE
Fix helm installation failure and cleanup values organization

### DIFF
--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -377,8 +377,8 @@ data:
             <key>PlistPath</key>
             <string>Contents/Info.plist</string>
           </dict>
-          {{- if .Values.kexts.add }} 
-          {{- range .Values.kexts.kextsToAdd }}
+          {{- if .Values.macos.kexts.add }} 
+          {{- range .Values.macos.kexts.kextsToAdd }}
           <dict>
             <key>Arch</key>
             <string>Any</string>
@@ -744,7 +744,7 @@ data:
           <key>TakeoffDelay</key>
           <integer>0</integer>
           <key>Timeout</key>
-          <integer>{{ .Values.openCore.boot.timeout }}</integer>
+          <integer>{{ .Values.macos.openCore.boot.timeout }}</integer>
         </dict>
         <key>Debug</key>
         <dict>
@@ -851,7 +851,7 @@ data:
             <key>SystemAudioVolume</key>
             <data>Rg==</data>
             <key>boot-args</key>
-            <string>{{ .Values.configPlist.bootArgs }}</string>
+            <string>{{ .Values.macos.configPlist.bootArgs }}</string>
             <key>run-efi-updater</key>
             <string>No</string>
             <key>csr-active-config</key>
@@ -918,7 +918,7 @@ data:
           <key>AdviseWindows</key>
           <false/>
           <key>MLB</key>
-          <string>{{ .Values.configPlist.MLB }}</string>
+          <string>{{ .Values.macos.configPlist.MLB }}</string>
           <key>ROM</key>
           <data>
           m7zhIYfl
@@ -926,11 +926,11 @@ data:
           <key>SpoofVendor</key>
           <true/>
           <key>SystemProductName</key>
-          <string>{{ .Values.configPlist.SystemProductName }}</string>
+          <string>{{ .Values.macos.configPlist.SystemProductName }}</string>
           <key>SystemSerialNumber</key>
-          <string>{{ .Values.configPlist.SystemSerialNumber }}</string>
+          <string>{{ .Values.macos.configPlist.SystemSerialNumber }}</string>
           <key>SystemUUID</key>
-          <string>{{ .Values.configPlist.SystemUUID }}</string>
+          <string>{{ .Values.macos.configPlist.SystemUUID }}</string>
         </dict>
         <key>UpdateDataHub</key>
         <true/>
@@ -1103,21 +1103,20 @@ data:
     #/bin/sh
 
     # Add extra kexts to EFI/OC/kexts
-    {{- if .Values.kexts.add }}
-    {{- range .Values.kexts.kextsToAdd }}
+    {{- if .Values.macos.kexts.add }}
+    {{- range .Values.macos.kexts.kextsToAdd }}
     {{- $rangeItem := . -}}
     {{- with $ }}
     echo 'Installing kext {{ $rangeItem.name }}..'
-    cp -r "{{ .Values.kexts.path }}/{{ $rangeItem.name }}" /home/{{ .Values.image.userName }}/OSX-KVM/OpenCore-Catalina/EFI/OC/Kexts/
+    cp -r "{{ .Values.macos.kexts.path }}/{{ $rangeItem.name }}" /home/{{ .Values.image.userName }}/OSX-KVM/OpenCore-Catalina/EFI/OC/Kexts/
     sudo chmod 755 /home/{{ .Values.image.userName }}/OSX-KVM/OpenCore-Catalina/EFI/OC/Kexts/{{ $rangeItem.name }} 
     {{- end }}
     {{- end }}
     {{- end }}
 
     # Rebuild Opencore.qcow2 after making changes to config.plist and etc..
-    {{- if .Values.openCore.rebuild }}
+    {{- if .Values.macos.openCore.rebuild }}
     echo 'Building new Opencore.qcow2..'
-    sudo apt install {{ .Values.openCore.kernel }} -y
     pushd OpenCore-Catalina/
     mkdir -p EFI/OC/Resources
     rm -f OpenCore.qcow2
@@ -1128,8 +1127,8 @@ data:
     popd
     {{- end }}
 
-    if ! [ -d "{{ .Values.qemu.systemInstaller.path }}" ]; then
-      mkdir -p {{ .Values.qemu.systemInstaller.path }}
+    if ! [ -d "{{ .Values.macos.installerSettings.path }}" ]; then
+      mkdir -p {{ .Values.macos.installerSettings.path }}
     fi
 
     if ! [ -d "/system_image/{{ .Values.serverName }}" ]; then
@@ -1137,11 +1136,11 @@ data:
     fi
 
     # Download and build installer image if no system drive found..
-    if ! [ -f "{{ .Values.qemu.systemInstaller.path }}/BaseSystem{{ .Values.qemu.systemInstaller.version }}.img" ]; then
-      echo "Downloading {{ .Values.qemu.systemInstaller.version }} base image.."
-      python fetch-macOS.py --version {{ .Values.qemu.systemInstaller.version }}
-      echo 'Converting downloaded BaseSystem.dmg into BaseSystem{{ .Values.qemu.systemInstaller.version }}.img and saving in {{ .Values.qemu.systemInstaller.path }}'
-      qemu-img convert BaseSystem.dmg -O qcow2 -p -c {{ .Values.qemu.systemInstaller.path }}/BaseSystem{{ .Values.qemu.systemInstaller.version }}.img
+    if ! [ -f "{{ .Values.macos.installerSettings.path }}/BaseSystem{{ .Values.macos.installerSettings.version }}.img" ]; then
+      echo "Downloading {{ .Values.macos.installerSettings.version }} base image.."
+      python fetch-macOS.py --version {{ .Values.macos.installerSettings.version }}
+      echo 'Converting downloaded BaseSystem.dmg into BaseSystem{{ .Values.macos.installerSettings.version }}.img and saving in {{ .Values.qemu.systemInstaller.path }}'
+      qemu-img convert BaseSystem.dmg -O qcow2 -p -c {{ .Values.macos.installerSettings.path }}/BaseSystem{{ .Values.qemu.systemInstaller.version }}.img
       rm -f BaseSystem.dmg
     else
       echo 'Base Image downloaded and converted into img already..'
@@ -1221,7 +1220,7 @@ data:
       -device ide-hd,bus=sata.2,drive=OpenCoreBoot \
       {{- if .Values.qemu.systemInstaller.enabled }}
         -device ide-hd,bus=sata.3,drive=InstallMedia \
-        -drive id=InstallMedia,if=none,file={{ .Values.qemu.systemInstaller.path }}/BaseSystem{{ .Values.qemu.systemInstaller.version }}.img,format=qcow2 \
+        -drive id=InstallMedia,if=none,file={{ .Values.macos.installerSettings.path }}/BaseSystem{{ .Values.macos.installerSettings.version }}.img,format=qcow2 \
       {{- end }}
       -drive id=MacHDD,if=none,file=/system_image/{{ .Values.serverName }}/mac_hdd_ng.img,format=qcow2 \
       -device ide-hd,bus=sata.4,drive=MacHDD \

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -12,37 +12,41 @@ image:
 # Please note, this must be a directory name within `/system_image` mounted at the bottom in extraVolumeMounts
 serverName: server
 
-# add kexts to EFI/OC/kexts and update config.plist
-#  make sure your kexts are in kexts.path
-kexts:
-  add: false
-  path: /system_image/kexts
-  kextsToAdd: {}
-  # - name: BrcmBluetoothInjector.kext
-  #   executablePath: Contents/MacOS/BrcmBluetoothInjector
-  #   plistPath: Contents/Info.plist
-  # - name: BrcmFirmwareData.kext
-  #   executablePath: Contents/MacOS/BrcmFirmwareData
-  #   plistPath: Contents/Info.plist
-  # - name: BrcmPatchRAM3.kext
-  #   executablePath: Contents/MacOS/BrcmPatchRAM3
-  #   plistPath: Contents/Info.plist
-
-# SMBIOS settings
-configPlist:
-  SystemProductName: iMacPro1,1
-  MLB: D25338500GUF8YLJA
-  SystemSerialNumber: D25LF7ZEF8JC
-  SystemUUID: 139C94D6-A533-47D2-874F-D365BFD8B047
-  bootArgs: '-v keepsyms=1 tlbto_us=0 vti=9 -wegoff agdpmod=pikera'
-
-openCore:
-  # Rebuild OpenCore.qcow2: this can be disabled if none of the above parameters in kexts, configPlist changes, and changing the
-  #  resolution are not desired, utilizing gpu passthrough and a few other things. Disabling is not recommended
-  rebuild: true
-  boot:
-    # set to zero to have OpenCore stay at boot menu
-    timeout: 0
+macos:
+  # add kexts to EFI/OC/kexts and update config.plist
+  #  make sure your kexts are in kexts.path
+  kexts:
+    add: false
+    path: /system_image/kexts
+    kextsToAdd: {}
+    # - name: BrcmBluetoothInjector.kext
+    #   executablePath: Contents/MacOS/BrcmBluetoothInjector
+    #   plistPath: Contents/Info.plist
+    # - name: BrcmFirmwareData.kext
+    #   executablePath: Contents/MacOS/BrcmFirmwareData
+    #   plistPath: Contents/Info.plist
+    # - name: BrcmPatchRAM3.kext
+    #   executablePath: Contents/MacOS/BrcmPatchRAM3
+    #   plistPath: Contents/Info.plist
+  # SMBIOS settings
+  configPlist:
+    SystemProductName: iMacPro1,1
+    MLB: D25338500GUF8YLJA
+    SystemSerialNumber: D25LF7ZEF8JC
+    SystemUUID: 139C94D6-A533-47D2-874F-D365BFD8B047
+    bootArgs: '-v keepsyms=1 tlbto_us=0 vti=9 -wegoff agdpmod=pikera'
+  openCore:
+    # Rebuild OpenCore.qcow2: this can be disabled if none of the above parameters in kexts, configPlist changes, and changing the
+    #  resolution are not desired, utilizing gpu passthrough and a few other things. Disabling is not recommended
+    rebuild: true
+    boot:
+      # set to zero to have OpenCore stay at boot menu
+      timeout: 0
+  installerSettings:
+    # if using more than one deployment, a write lock will be put on the system installer dmg, so this will need to be disabled
+    #  for other pods
+    version: 10.15.7
+    path: /system_image/installers
 
 # This section defines QEMU and virtlo parameters
 #
@@ -75,8 +79,6 @@ qemu:
     # if using more than one deployment, a write lock will be put on the system installer dmg, so this will need to be disabled
     #  for other pods
     enabled: false
-    version: 10.15.7
-    path: /system_image/installers
     downloadDelay: 15
     # can be `writethrough`, `writeback`, or `none`
     cache: none


### PR DESCRIPTION
This PR addresses the leftover attribute and command to install a kernel in the pod at runtime. This has been migrated to the Dockerfile itself, so it doesn't take any longer for the pod to start. I accidentally left this in the chart template when I was testing. 😅

Currently, this prevents helm from installing the chart, so this fix is the main reason for this PR.

Additionally, this PR migrates all macOS specific commands out into their own value map so it is a bit cleaner organizationally speaking.