### PR TITLE
3.1. archlinux:base-devel. glibc everywhere. Forgo testing repos.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Version|Date|Notes|
 |---|---|---|
+|3.1|2021-02-21|Remove testing repos. Switch to base-devel. We shouldn't be using testing repos in a Dockerfile for light increase in stability. Add the mandatory glibc patch to every pacman until someone upstream fixes it.|
 |   |2021-02-07|Add NOPICKER environment variable to :naked image for effortless boot toggling.|
 |   |2021-02-07|Add MAC_ADDRESS environment variable.|
 |   |2021-02-03|Employ wget --no-verbose to avoid buffer overload in hub.docker.com.|

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # Repo:             https://github.com/sickcodes/Docker-OSX/
 # Title:            Mac on Docker (Docker-OSX)
 # Author:           Sick.Codes https://sick.codes/
-# Version:          3.0
+# Version:          3.1
 # License:          GPLv3+
 #
 # All credits for OSX-KVM and the rest at @Kholia's repo: https://github.com/kholia/osx-kvm
@@ -50,7 +50,7 @@
 #       docker run ... -e EXTRA="-usb -device usb-host,hostbus=1,hostaddr=8" ...
 #       # you will also need to pass the device to the container
 
-FROM archlinux:latest
+FROM archlinux:base-devel
 
 MAINTAINER 'https://sick.codes' <https://sick.codes>
 
@@ -68,8 +68,8 @@ ARG MIRROR_COUNT=10
 
 # TEMP-FIX for pacman issue
 RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
-    && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/$patched_glibc" \
-    && bsdtar -C / -xvf "$patched_glibc"
+    && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
+    && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine."
 # TEMP-FIX for pacman issue
 
 RUN if [[ "${RANKMIRRORS}" ]]; then \
@@ -88,15 +88,21 @@ RUN if [[ "${RANKMIRRORS}" ]]; then \
 # This fails on hub.docker.com, useful for debugging in cloud
 # RUN [[ $(egrep -c '(svm|vmx)' /proc/cpuinfo) -gt 0 ]] || { echo KVM not possible on this host && exit 1; }
 
-RUN tee -a /etc/pacman.conf <<< '[community-testing]' \
-    && tee -a /etc/pacman.conf <<< 'Include = /etc/pacman.d/mirrorlist'
+# RUN tee -a /etc/pacman.conf <<< '[community-testing]' \
+#     && tee -a /etc/pacman.conf <<< 'Include = /etc/pacman.d/mirrorlist'
 
-RUN pacman -Syu sudo git vim nano alsa-utils openssh --noconfirm \
+RUN pacman -Syu git vim nano alsa-utils openssh --noconfirm \
     && ln -s /bin/vim /bin/vi \
     && useradd arch -p arch \
     && tee -a /etc/sudoers <<< 'arch ALL=(ALL) NOPASSWD: ALL' \
     && mkdir /home/arch \
     && chown arch:arch /home/arch
+
+# TEMP-FIX for pacman issue
+RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
+    && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
+    && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine."
+# TEMP-FIX for pacman issue
 
 # allow ssh to container
 RUN mkdir -m 700 /root/.ssh
@@ -146,6 +152,12 @@ RUN touch enable-ssh.sh \
 
 RUN yes | sudo pacman -Syu qemu libvirt dnsmasq virt-manager bridge-utils openresolv jack ebtables edk2-ovmf netctl libvirt-dbus --overwrite --noconfirm \
     && yes | sudo pacman -Scc
+
+# TEMP-FIX for pacman issue
+RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
+    && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
+    && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine."
+# TEMP-FIX for pacman issue
 
 # RUN sudo systemctl enable libvirtd.service
 # RUN sudo systemctl enable virtlogd.service

--- a/Dockerfile.auto
+++ b/Dockerfile.auto
@@ -7,7 +7,7 @@
 # 
 # Title:            Mac on Docker (Docker-OSX) [AUTOINSTALL]
 # Author:           Sick.Codes https://twitter.com/sickcodes       
-# Version:          3.0
+# Version:          3.1
 # License:          GPLv3+
 # Repository:       https://github.com/sickcodes/Docker-OSX
 # 
@@ -69,6 +69,12 @@ RUN if [[ "${RANKMIRRORS}" ]]; then \
     ; fi \
     ; yes | pacman -Scc
 
+# TEMP-FIX for pacman issue
+RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
+    && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
+    && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine."
+# TEMP-FIX for pacman issue
+
 RUN pacman -Syu xorg-server-xvfb wget xterm xorg-xhost xorg-xrandr sshpass --noconfirm \
     && if [[ "${SCROT}" ]]; then \
         pacman -Syu scrot base-devel --noconfirm \
@@ -85,6 +91,12 @@ RUN pacman -Syu xorg-server-xvfb wget xterm xorg-xhost xorg-xrandr sshpass --noc
         && chmod +x /usr/bin/scrotcat \
     ; fi \
     ; yes | pacman -Scc
+
+# TEMP-FIX for pacman issue
+RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
+    && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
+    && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine."
+# TEMP-FIX for pacman issue
 
 USER arch
 

--- a/Dockerfile.naked
+++ b/Dockerfile.naked
@@ -7,7 +7,7 @@
 # 
 # Title:            Mac on Docker (Docker-OSX) [AUTOINSTALL]
 # Author:           Sick.Codes https://twitter.com/sickcodes       
-# Version:          3.0
+# Version:          3.1
 # License:          GPLv3+
 # Repository:       https://github.com/sickcodes/Docker-OSX
 # 
@@ -55,6 +55,12 @@ RUN if [[ "${RANKMIRRORS}" ]]; then { pacman -Sy wget --noconfirm || pacman -Syu
     && tee -a /etc/pacman.d/mirrorlist <<< 'Server = https://mirror.rackspace.com/archlinux/$repo/os/$arch' \
     && cat /etc/pacman.d/mirrorlist ; fi
 
+# TEMP-FIX for pacman issue
+RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
+    && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
+    && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine."
+# TEMP-FIX for pacman issue
+
 # For taking screenshots of the Xfvb screen, useful during development.
 ARG SCROT
 
@@ -74,6 +80,12 @@ RUN pacman -Syu xorg-server-xvfb wget xterm xorg-xhost xorg-xrandr sshpass --noc
         && chmod +x /usr/bin/scrotcat \
     ; fi \
     ; yes | pacman -Scc
+
+# TEMP-FIX for pacman issue
+RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
+    && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
+    && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine."
+# TEMP-FIX for pacman issue
 
 USER arch
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ docker run -it \
     sickcodes/docker-osx:naked
 ```
 
-# Features In Docker-OSX v3.0
+# Features In Docker-OSX v3.1
 - Full auto mode: boot straight to OSX shell.
 - sickcodes/docker-osx:latest - original base recovery image (safe)
 - sickcodes/docker-osx:naked - supply your own .img file (safe)


### PR DESCRIPTION
- Elevate to version  `3.1`

- Remove `testing` repos as we are not test subjects, currently.

- `archlinux:base-devel` image to skip simple packages.

- Add `glibc` overrides after every `pacman -Syu` which is currently required for non-Arch builds:

```dockerfile
# TEMP-FIX for pacman issue
RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
    && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
    && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine."
# TEMP-FIX for pacman issue
```