### PR TITLE
Add WIDTH and HEIGHT environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 |Version|Date|Notes|
 |---|---|---|
-|   |2021-03-04|Add `-e MASTER_PLIST_URL` to all images to allow using your own remote plist.|
-|   |2021-03-03|Add WIDTH and HEIGHT to set the x and y resolutions, use in conjuction with serial numbers.|
+|4.1|2021-03-04|Add `-e MASTER_PLIST_URL` to all images to allow using your own remote plist.|
+|   |2021-03-03|Add `WIDTH` and `HEIGHT` to set the x and y resolutions, use in conjuction with serial numbers.|
 |   |2021-03-02|Add ADDITIONAL_PORTS, for example `-e ADDITIONAL_PORTS='hostfwd=tcp::23-:23,'`|
 |4.0|2021-02-27|Add big-sur support. Use `sickcodes/docker-osx:big-sur` or build using `--build-arg VERSION=11`|
 |   |2021-02-26|Change `-e NOPICKER=true` to simply do `sed -i '/^.*InstallMedia.*/d' Launch.sh` and `export BOOTDISK=/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore-nopicker.qcow2`.|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Version|Date|Notes|
 |---|---|---|
+|   |2021-03-04|Add `-e MASTER_PLIST_URL` to all images to allow using your own remote plist.|
 |   |2021-03-03|Add WIDTH and HEIGHT to set the x and y resolutions, use in conjuction with serial numbers.|
 |   |2021-03-02|Add ADDITIONAL_PORTS, for example `-e ADDITIONAL_PORTS='hostfwd=tcp::23-:23,'`|
 |4.0|2021-02-27|Add big-sur support. Use `sickcodes/docker-osx:big-sur` or build using `--build-arg VERSION=11`|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Version|Date|Notes|
 |---|---|---|
+|   |2021-03-03|Add WIDTH and HEIGHT to set the x and y resolutions, use in conjuction with serial numbers.|
 |   |2021-03-02|Add ADDITIONAL_PORTS, for example `-e ADDITIONAL_PORTS='hostfwd=tcp::23-:23,'`|
 |4.0|2021-02-27|Add big-sur support. Use `sickcodes/docker-osx:big-sur` or build using `--build-arg VERSION=11`|
 |   |2021-02-26|Change `-e NOPICKER=true` to simply do `sed -i '/^.*InstallMedia.*/d' Launch.sh` and `export BOOTDISK=/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore-nopicker.qcow2`.|

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,12 @@
 #  / /_/ / /_/ / /__/ ,< /  __/ /  / /_/ /___/ /   |
 # /_____/\____/\___/_/|_|\___/_/   \____//____/_/|_|
 #
-# Repo:             https://github.com/sickcodes/Docker-OSX/
-# Title:            Mac on Docker (Docker-OSX)
-# Author:           Sick.Codes https://sick.codes/
-# Version:          4.0
+# Title:            Docker-OSX (Mac on Docker)
+# Author:           Sick.Codes https://twitter.com/sickcodes
+# Version:          4.1
 # License:          GPLv3+
+# Repository:       https://github.com/sickcodes/Docker-OSX
+# Website:          https://sick.codes
 #
 # All credits for OSX-KVM and the rest at @Kholia's repo: https://github.com/kholia/osx-kvm
 # OpenCore support go to https://github.com/Leoyzen/KVM-Opencore

--- a/Dockerfile
+++ b/Dockerfile
@@ -273,6 +273,8 @@ ENV NOPICKER=false
 ENV WIDTH=1920
 ENV HEIGHT=1080
 
+ENV MASTER_PLIST_URL="https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/custom/config-nopicker-custom.plist"
+
 VOLUME ["/tmp/.X11-unix"]
 
 # check if /image is a disk image or a directory. This allows you to optionally use -v disk.img:/image
@@ -307,6 +309,7 @@ CMD sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDIS
     ; } \
     ; [[ "${GENERATE_UNIQUE}" == true ]] && { \
         ./Docker-OSX/custom/generate-unique-machine-values.sh \
+            --master-plist-url="${MASTER_PLIST_URL}" \
             --count 1 \
             --tsv ./serial.tsv \
             --bootdisks \
@@ -318,6 +321,7 @@ CMD sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDIS
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
             source "${ENV:=/env}" \
             || ./Docker-OSX/custom/generate-specific-bootdisk.sh \
+            --master-plist-url="${MASTER_PLIST_URL}" \
             --model "${DEVICE_MODEL}" \
             --serial "${SERIAL}" \
             --board-serial "${BOARD_SERIAL}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -319,8 +319,8 @@ CMD sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDIS
             --output-env "${ENV:=/env}" || exit 1 \
     ; } \
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
-            source "${ENV:=/env}" \
-            || ./Docker-OSX/custom/generate-specific-bootdisk.sh \
+            source "${ENV:=/env}" 2>/dev/null \
+            ; ./Docker-OSX/custom/generate-specific-bootdisk.sh \
             --master-plist-url="${MASTER_PLIST_URL}" \
             --model "${DEVICE_MODEL}" \
             --serial "${SERIAL}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -316,7 +316,7 @@ CMD sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDIS
             --width "${WIDTH:-1920}" \
             --height "${HEIGHT:-1080}" \
             --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" \
-            --output-env "${ENV:=/env}" || exit 1 \
+            --output-env "${ENV:=/env}" \
     ; } \
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
             source "${ENV:=/env}" 2>/dev/null \
@@ -329,7 +329,7 @@ CMD sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDIS
             --mac-address "${MAC_ADDRESS}" \
             --width "${WIDTH:-1920}" \
             --height "${HEIGHT:-1080}" \
-            --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" || exit 1 \
+            --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" \
     ; } \
     ; case "$(file --brief /bootdisk)" in \
         QEMU\ QCOW2\ Image* ) export BOOTDISK=/bootdisk \

--- a/Dockerfile
+++ b/Dockerfile
@@ -259,8 +259,19 @@ ENV NETWORKING=vmxnet3
 
 ENV NOPICKER=false
 
-ENV UNIQUE=false
-# Boolean for generating a bootdisk with new serials.
+# Boolean for generating a bootdisk with new random serials.
+ENV GENERATE_UNIQUE=false
+
+# Boolean for generating a bootdisk with specific serials.
+ENV GENERATE_SPECIFIC=false
+
+# boolean for skipping the disk selection menu at in the boot process
+ENV NOPICKER=false
+
+# The x and y coordinates for resolution.
+# Must be used with either -e GENERATE_UNIQUE=true or -e GENERATE_SPECIFIC=true.
+ENV WIDTH=1920
+ENV HEIGHT=1080
 
 VOLUME ["/tmp/.X11-unix"]
 
@@ -296,11 +307,13 @@ CMD sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDIS
     ; } \
     ; [[ "${GENERATE_UNIQUE}" == true ]] && { \
         ./Docker-OSX/custom/generate-unique-machine-values.sh \
-        --count 1 \
-        --tsv ./serial.tsv \
-        --bootdisks \
-        --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" \
-        --output-env "${ENV:=/env}" || exit 1 \
+            --count 1 \
+            --tsv ./serial.tsv \
+            --bootdisks \
+            --width "${WIDTH:-1920}" \
+            --height "${HEIGHT:-1080}" \
+            --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" \
+            --output-env "${ENV:=/env}" || exit 1 \
     ; } \
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
             source "${ENV:=/env}" \
@@ -310,6 +323,8 @@ CMD sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDIS
             --board-serial "${BOARD_SERIAL}" \
             --uuid "${UUID}" \
             --mac-address "${MAC_ADDRESS}" \
+            --width "${WIDTH:-1920}" \
+            --height "${HEIGHT:-1080}" \
             --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" || exit 1 \
     ; } \
     ; case "$(file --brief /bootdisk)" in \

--- a/Dockerfile.auto
+++ b/Dockerfile.auto
@@ -152,6 +152,7 @@ CMD echo "${BOILERPLATE}" \
     ; } \
     ; [[ "${GENERATE_UNIQUE}" == true ]] && { \
         ./Docker-OSX/custom/generate-unique-machine-values.sh \
+            --master-plist-url="${MASTER_PLIST_URL}" \
             --count 1 \
             --tsv ./serial.tsv \
             --bootdisks \
@@ -163,6 +164,7 @@ CMD echo "${BOILERPLATE}" \
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
             source "${ENV:=/env}" \
             || ./Docker-OSX/custom/generate-specific-bootdisk.sh \
+            --master-plist-url="${MASTER_PLIST_URL}" \
             --model "${DEVICE_MODEL}" \
             --serial "${SERIAL}" \
             --board-serial "${BOARD_SERIAL}" \

--- a/Dockerfile.auto
+++ b/Dockerfile.auto
@@ -159,7 +159,7 @@ CMD echo "${BOILERPLATE}" \
             --width "${WIDTH:-1920}" \
             --height "${HEIGHT:-1080}" \
             --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" \
-            --output-env "${ENV:=/env}" || exit 1 \
+            --output-env "${ENV:=/env}" \
     ; } \
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
             source "${ENV:=/env}" 2>/dev/null \
@@ -172,7 +172,7 @@ CMD echo "${BOILERPLATE}" \
             --mac-address "${MAC_ADDRESS}" \
             --width "${WIDTH:-1920}" \
             --height "${HEIGHT:-1080}" \
-            --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" || exit 1 \
+            --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}"  \
     ; } \
     ; case "$(file --brief /bootdisk)" in \
         QEMU\ QCOW2\ Image* ) export BOOTDISK=/bootdisk \

--- a/Dockerfile.auto
+++ b/Dockerfile.auto
@@ -152,11 +152,13 @@ CMD echo "${BOILERPLATE}" \
     ; } \
     ; [[ "${GENERATE_UNIQUE}" == true ]] && { \
         ./Docker-OSX/custom/generate-unique-machine-values.sh \
-        --count 1 \
-        --tsv ./serial.tsv \
-        --bootdisks \
-        --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" \
-        --output-env "${ENV:=/env}" || exit 1 \
+            --count 1 \
+            --tsv ./serial.tsv \
+            --bootdisks \
+            --width "${WIDTH:-1920}" \
+            --height "${HEIGHT:-1080}" \
+            --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" \
+            --output-env "${ENV:=/env}" || exit 1 \
     ; } \
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
             source "${ENV:=/env}" \
@@ -166,6 +168,8 @@ CMD echo "${BOILERPLATE}" \
             --board-serial "${BOARD_SERIAL}" \
             --uuid "${UUID}" \
             --mac-address "${MAC_ADDRESS}" \
+            --width "${WIDTH:-1920}" \
+            --height "${HEIGHT:-1080}" \
             --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" || exit 1 \
     ; } \
     ; case "$(file --brief /bootdisk)" in \

--- a/Dockerfile.auto
+++ b/Dockerfile.auto
@@ -3,13 +3,14 @@
 #    / __ \____  _____/ /_____  _____/ __ \/ ___/ |/ /
 #   / / / / __ \/ ___/ //_/ _ \/ ___/ / / /\__ \|   / 
 #  / /_/ / /_/ / /__/ ,< /  __/ /  / /_/ /___/ /   |  
-# /_____/\____/\___/_/|_|\___/_/   \____//____/_/|_|  AUTOINSTALL
+# /_____/\____/\___/_/|_|\___/_/   \____//____/_/|_|  :AUTO
 # 
-# Title:            Mac on Docker (Docker-OSX) [AUTOINSTALL]
-# Author:           Sick.Codes https://twitter.com/sickcodes       
-# Version:          4.0
+# Title:            Docker-OSX (Mac on Docker)
+# Author:           Sick.Codes https://twitter.com/sickcodes
+# Version:          4.1
 # License:          GPLv3+
 # Repository:       https://github.com/sickcodes/Docker-OSX
+# Website:          https://sick.codes
 # 
 # This Dockerfile is a pre-installed naked installation of Docker-OSX!
 # 

--- a/Dockerfile.auto
+++ b/Dockerfile.auto
@@ -162,8 +162,8 @@ CMD echo "${BOILERPLATE}" \
             --output-env "${ENV:=/env}" || exit 1 \
     ; } \
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
-            source "${ENV:=/env}" \
-            || ./Docker-OSX/custom/generate-specific-bootdisk.sh \
+            source "${ENV:=/env}" 2>/dev/null \
+            ; ./Docker-OSX/custom/generate-specific-bootdisk.sh \
             --master-plist-url="${MASTER_PLIST_URL}" \
             --model "${DEVICE_MODEL}" \
             --serial "${SERIAL}" \

--- a/Dockerfile.naked
+++ b/Dockerfile.naked
@@ -5,7 +5,7 @@
 #  / /_/ / /_/ / /__/ ,< /  __/ /  / /_/ /___/ /   |  
 # /_____/\____/\___/_/|_|\___/_/   \____//____/_/|_|  :NAKED
 # 
-# Title:            Docker-OSX (Mac on Docker) [AUTOINSTALL]
+# Title:            Docker-OSX (Mac on Docker)
 # Author:           Sick.Codes https://twitter.com/sickcodes
 # Version:          4.1
 # License:          GPLv3+

--- a/Dockerfile.naked
+++ b/Dockerfile.naked
@@ -129,7 +129,7 @@ CMD sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDIS
             --width "${WIDTH:-1920}" \
             --height "${HEIGHT:-1080}" \
             --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" \
-            --output-env "${ENV:=/env}" || exit 1 \
+            --output-env "${ENV:=/env}" \
     ; } \
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
             source "${ENV:=/env}" 2>/dev/null \
@@ -142,7 +142,8 @@ CMD sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDIS
             --mac-address "${MAC_ADDRESS}" \
             --width "${WIDTH:-1920}" \
             --height "${HEIGHT:-1080}" \
-            --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}"
+            --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" \
+    ; } \
     ; case "$(file --brief /bootdisk)" in \
         QEMU\ QCOW2\ Image* ) export BOOTDISK=/bootdisk \
             ;; \

--- a/Dockerfile.naked
+++ b/Dockerfile.naked
@@ -122,11 +122,13 @@ CMD sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDIS
     ; } \
     ; [[ "${GENERATE_UNIQUE}" == true ]] && { \
         ./Docker-OSX/custom/generate-unique-machine-values.sh \
-        --count 1 \
-        --tsv ./serial.tsv \
-        --bootdisks \
-        --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" \
-        --output-env "${ENV:=/env}" || exit 1 \
+            --count 1 \
+            --tsv ./serial.tsv \
+            --bootdisks \
+            --width "${WIDTH:-1920}" \
+            --height "${HEIGHT:-1080}" \
+            --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" \
+            --output-env "${ENV:=/env}" || exit 1 \
     ; } \
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
             source "${ENV:=/env}" \
@@ -136,6 +138,8 @@ CMD sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDIS
             --board-serial "${BOARD_SERIAL}" \
             --uuid "${UUID}" \
             --mac-address "${MAC_ADDRESS}" \
+            --width "${WIDTH:-1920}" \
+            --height "${HEIGHT:-1080}" \
             --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" || exit 1 \
     ; } \
     ; case "$(file --brief /bootdisk)" in \

--- a/Dockerfile.naked
+++ b/Dockerfile.naked
@@ -132,8 +132,8 @@ CMD sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDIS
             --output-env "${ENV:=/env}" || exit 1 \
     ; } \
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
-            source "${ENV:=/env}" \
-            || ./Docker-OSX/custom/generate-specific-bootdisk.sh \
+            source "${ENV:=/env}" 2>/dev/null \
+            ; ./Docker-OSX/custom/generate-specific-bootdisk.sh \
             --master-plist-url="${MASTER_PLIST_URL}" \
             --model "${DEVICE_MODEL}" \
             --serial "${SERIAL}" \
@@ -142,8 +142,7 @@ CMD sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDIS
             --mac-address "${MAC_ADDRESS}" \
             --width "${WIDTH:-1920}" \
             --height "${HEIGHT:-1080}" \
-            --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" || exit 1 \
-    ; } \
+            --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}"
     ; case "$(file --brief /bootdisk)" in \
         QEMU\ QCOW2\ Image* ) export BOOTDISK=/bootdisk \
             ;; \

--- a/Dockerfile.naked
+++ b/Dockerfile.naked
@@ -3,13 +3,14 @@
 #    / __ \____  _____/ /_____  _____/ __ \/ ___/ |/ /
 #   / / / / __ \/ ___/ //_/ _ \/ ___/ / / /\__ \|   / 
 #  / /_/ / /_/ / /__/ ,< /  __/ /  / /_/ /___/ /   |  
-# /_____/\____/\___/_/|_|\___/_/   \____//____/_/|_|  NAKED/SUPPLY_YOUR_OWN
+# /_____/\____/\___/_/|_|\___/_/   \____//____/_/|_|  :NAKED
 # 
-# Title:            Mac on Docker (Docker-OSX) [AUTOINSTALL]
-# Author:           Sick.Codes https://twitter.com/sickcodes       
-# Version:          4.0
+# Title:            Docker-OSX (Mac on Docker) [AUTOINSTALL]
+# Author:           Sick.Codes https://twitter.com/sickcodes
+# Version:          4.1
 # License:          GPLv3+
 # Repository:       https://github.com/sickcodes/Docker-OSX
+# Website:          https://sick.codes
 # 
 # This image won't run unless you supply a disk image using:
 #       -v ${PWD}/mac_hdd_ng.img:/image

--- a/Dockerfile.naked
+++ b/Dockerfile.naked
@@ -122,6 +122,7 @@ CMD sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDIS
     ; } \
     ; [[ "${GENERATE_UNIQUE}" == true ]] && { \
         ./Docker-OSX/custom/generate-unique-machine-values.sh \
+            --master-plist-url="${MASTER_PLIST_URL}" \
             --count 1 \
             --tsv ./serial.tsv \
             --bootdisks \
@@ -133,6 +134,7 @@ CMD sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDIS
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
             source "${ENV:=/env}" \
             || ./Docker-OSX/custom/generate-specific-bootdisk.sh \
+            --master-plist-url="${MASTER_PLIST_URL}" \
             --model "${DEVICE_MODEL}" \
             --serial "${SERIAL}" \
             --board-serial "${BOARD_SERIAL}" \

--- a/README.md
+++ b/README.md
@@ -784,7 +784,7 @@ docker run -it \
     sickcodes/docker-osx:auto
 ```
 
-# This example generates a specific set of serial numbers at runtime, with your existing image, at 1000x1000 display resolution.
+### This example generates a specific set of serial numbers at runtime, with your existing image, at 1000x1000 display resolution.
 
 ```bash
 # run an existing image in current directory, with a screen, with SSH, with nopicker, and save the bootdisk for later.
@@ -823,36 +823,6 @@ Or you can generate them inside the `./custom` folder. And then use:
     -e UUID="" \
     -e MAC_ADDRESS="" \
 ```
-
-# Change Resolution Docker-OSX
-
-The display resolution is controlled by this line:
-
-https://github.com/sickcodes/Docker-OSX/blob/master/custom/config-nopicker-custom.plist#L819
-
-However, you need to mount that disk. Boring!
-
-Instead, you can simply add the following to any image:
-
-```bash
--e GENERATE_UNIQUE=true \
--e WIDTH=1920 \
--e HEIGHT=1080 \
-```
-
-It will take around 1 minute longer to boot because it will make a new boot partition.
-
-```bash
--e GENERATE_SPECIFIC=true \
--e WIDTH=1920 \
--e HEIGHT=1080 \
--e SERIAL="" \
--e BOARD_SERIAL="" \
--e UUID="" \
--e MAC_ADDRESS="" \
-```
-
-Must be used with either `-e GENERATE_UNIQUE=true` or `-e GENERATE_SPECIFIC=true`.
 
 #### Persistence from generating serial numbers is obviously ideal:
 
@@ -948,6 +918,97 @@ generate-specific-bootdisk.sh \
     --uuid "${UUID}" \
     --mac-address "${MAC_ADDRESS}" \
     --output-bootdisk OpenCore-nopicker.qcow2
+```
+
+# Change Resolution Docker-OSX - change resolution OpenCore OSX-KVM 
+
+The display resolution is controlled by this line:
+
+https://github.com/sickcodes/Docker-OSX/blob/master/custom/config-nopicker-custom.plist#L819
+
+Instead of mounting that disk, Docker-OSX will generate a new `OpenCore.qcow2` by using this one cool trick:
+
+```bash
+-e GENERATE_UNIQUE=true \
+-e WIDTH=800 \
+-e HEIGHT=600 \
+```
+
+To use `WIDTH`/`HEIGHT`, you must use with either `-e GENERATE_UNIQUE=true` or `-e GENERATE_SPECIFIC=true`.
+
+It will take around 30 seconds longer to boot because it needs to make a new boot partition using `libguestfs`.
+
+```bash
+-e GENERATE_SPECIFIC=true \
+-e WIDTH=1920 \
+-e HEIGHT=1080 \
+-e SERIAL="" \
+-e BOARD_SERIAL="" \
+-e UUID="" \
+-e MAC_ADDRESS="" \
+```
+
+## Change Docker-OSX Resolution Examples
+
+```bash
+# using an image in your current directory
+stat mac_hdd_ng.img
+
+docker run -it \
+    --device /dev/kvm \
+    -p 50922:10022 \
+    -v "${PWD}/mac_hdd_ng.img:/image" \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -e "DISPLAY=${DISPLAY:-:0.0}" \
+    -e GENERATE_SPECIFIC=true \
+    -e DEVICE_MODEL="iMacPro1,1" \
+    -e SERIAL="C02TW0WAHX87" \
+    -e BOARD_SERIAL="C027251024NJG36UE" \
+    -e UUID="5CCB366D-9118-4C61-A00A-E5BAF3BED451" \
+    -e MAC_ADDRESS="A8:5C:2C:9A:46:2F" \
+    -e MASTER_PLIST_URL=https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/custom/config-nopicker-custom.plist \
+    -e WIDTH=1600 \
+    -e HEIGHT=900 \
+    sickcodes/docker-osx:naked
+```
+
+```bash
+# generating random serial numbers, using the DIY installer, along with the screen resolution changes.
+docker run -it \
+    --device /dev/kvm \
+    -p 50922:10022 \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -e "DISPLAY=${DISPLAY:-:0.0}" \
+    -e GENERATE_UNIQUE=true \
+    -e WIDTH=800 \
+    -e HEIGHT=600 \
+    sickcodes/docker-osx:latest
+
+
+```
+
+
+Here's a few other resolutions! If you resolution is invalid, it will default to 800x600.
+
+```
+    -e WIDTH=800 \
+    -e HEIGHT=600 \
+```
+```
+    -e WIDTH=1280 \
+    -e HEIGHT=768 \
+```
+```
+    -e WIDTH=1600 \
+    -e HEIGHT=900 \
+```
+```
+    -e WIDTH=1920 \
+    -e HEIGHT=1080 \
+```
+```
+    -e WIDTH=2560 \
+    -e HEIGHT=1600 \
 ```
 
 # Allow USB passthrough

--- a/custom/config-nopicker-custom.plist
+++ b/custom/config-nopicker-custom.plist
@@ -816,7 +816,7 @@
 			<key>ReplaceTabWithSpace</key>
 			<false/>
 			<key>Resolution</key>
-			<string>1920x1080@32</string>
+			<string>{{WIDTH}}x{{HEIGHT}}@32</string>
 			<key>SanitiseClearScreen</key>
 			<false/>
 			<key>TextRenderer</key>

--- a/custom/generate-specific-bootdisk.sh
+++ b/custom/generate-specific-bootdisk.sh
@@ -194,11 +194,11 @@ generate_bootdisk () {
     elif [[ "${MASTER_PLIST}" ]] && [[ "${MASTER_PLIST_URL}" ]]; then
         echo 'You specified both a custom plist file AND a custom plist url. Use one or the other.'
     elif [[ "${MASTER_PLIST_URL}" ]]; then
-        wget -O "./${MASTER_PLIST:=/config-custom.plist}" "${MASTER_PLIST_URL}" \
+        wget -O "${MASTER_PLIST:=./config-custom.plist}" "${MASTER_PLIST_URL}" \
             || echo "Could not download ${MASTER_PLIST_URL}" && exit 1
     else
         MASTER_PLIST_URL='https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/custom/config-nopicker-custom.plist'
-        wget -O "./${MASTER_PLIST:=/config-nopicker-custom.plist}" "${MASTER_PLIST_URL}" \
+        wget -O "${MASTER_PLIST:=./config-nopicker-custom.plist}" "${MASTER_PLIST_URL}" \
             || echo "Could not download ${MASTER_PLIST_URL}" && exit 1
     fi
 

--- a/custom/generate-specific-bootdisk.sh
+++ b/custom/generate-specific-bootdisk.sh
@@ -191,9 +191,9 @@ generate_bootdisk () {
 
     if [[ "${MASTER_PLIST}" ]]; then
         [[ -e "${MASTER_PLIST}" ]] || echo "Could not find: ${MASTER_PLIST}"
-    elif [[ "${MASTER_PLIST}" ]] && [[ "${MASTER_PLIST_URL}" ]];
+    elif [[ "${MASTER_PLIST}" ]] && [[ "${MASTER_PLIST_URL}" ]]; then
         echo 'You specified both a custom plist file AND a custom plist url. Use one or the other.'
-    elif [[ "${MASTER_PLIST_URL}" ]];
+    elif [[ "${MASTER_PLIST_URL}" ]]; then
         wget -o "./${MASTER_PLIST:=/config-custom.plist}" "${MASTER_PLIST_URL}" \
             || echo "Could not download ${MASTER_PLIST_URL}" && exit 1
     else

--- a/custom/generate-specific-bootdisk.sh
+++ b/custom/generate-specific-bootdisk.sh
@@ -195,11 +195,11 @@ generate_bootdisk () {
         echo 'You specified both a custom plist file AND a custom plist url. Use one or the other.'
     elif [[ "${MASTER_PLIST_URL}" ]]; then
         wget -O "${MASTER_PLIST:=./config-custom.plist}" "${MASTER_PLIST_URL}" \
-            || echo "Could not download ${MASTER_PLIST_URL}" && exit 1
+            || { echo "Could not download ${MASTER_PLIST_URL}" && exit 1 ; }
     else
         MASTER_PLIST_URL='https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/custom/config-nopicker-custom.plist'
         wget -O "${MASTER_PLIST:=./config-nopicker-custom.plist}" "${MASTER_PLIST_URL}" \
-            || echo "Could not download ${MASTER_PLIST_URL}" && exit 1
+            || { echo "Could not download ${MASTER_PLIST_URL}" && exit 1 ; }
     fi
 
 

--- a/custom/generate-specific-bootdisk.sh
+++ b/custom/generate-specific-bootdisk.sh
@@ -194,11 +194,11 @@ generate_bootdisk () {
     elif [[ "${MASTER_PLIST}" ]] && [[ "${MASTER_PLIST_URL}" ]]; then
         echo 'You specified both a custom plist file AND a custom plist url. Use one or the other.'
     elif [[ "${MASTER_PLIST_URL}" ]]; then
-        wget -o "./${MASTER_PLIST:=/config-custom.plist}" "${MASTER_PLIST_URL}" \
+        wget -O "./${MASTER_PLIST:=/config-custom.plist}" "${MASTER_PLIST_URL}" \
             || echo "Could not download ${MASTER_PLIST_URL}" && exit 1
     else
         MASTER_PLIST_URL='https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/custom/config-nopicker-custom.plist'
-        wget -o "./${MASTER_PLIST:=/config-nopicker-custom.plist}" "${MASTER_PLIST_URL}" \
+        wget -O "./${MASTER_PLIST:=/config-nopicker-custom.plist}" "${MASTER_PLIST_URL}" \
             || echo "Could not download ${MASTER_PLIST_URL}" && exit 1
     fi
 

--- a/custom/generate-specific-bootdisk.sh
+++ b/custom/generate-specific-bootdisk.sh
@@ -15,12 +15,14 @@ help_text="Usage: generate-specific-bootdisk.sh
 
 General options:
     --model <string>                Device model, e.g. 'iMacPro1,1'
-    --serial <filename>             Device Serial number.
-    --board-serial <filename>       Board Serial number.
-    --uuid <filename>               SmUUID.
-    --mac-address <string>          Used to set the ROM value; lowercased and without a colon.
-    --output-bootdisk <filename>    Optionally change the bootdisk output filename.
-    --custom-plist <filename>       Optionally change the input plist.
+    --serial <filename>             Device Serial number
+    --board-serial <filename>       Board Serial number
+    --uuid <filename>               SmUUID
+    --mac-address <string>          Used to set the ROM value; lowercased and without a colon
+    --width <string>                Resolution x axis length in pixels (default 1920)
+    --height <string>               Resolution y axis length in pixels (default 1080
+    --output-bootdisk <filename>    Optionally change the bootdisk output filename
+    --custom-plist <filename>       Optionally change the input plist
 
     --help, -h, help                Display this help and exit
 
@@ -31,7 +33,9 @@ Example:
         --board-serial C027251024NJG36UE \
         --uuid 5CCB366D-9118-4C61-A00A-E5BAF3BED451 \
         --mac-address A8:5C:2C:9A:46:2F \
-        --output-bootdisk OpenCore-nopicker.qcow2
+        --output-bootdisk OpenCore-nopicker.qcow2 \
+        --widht 1920 \
+        --height 1080
 
 Author:  Sick.Codes https://sick.codes/
 Project: https://github.com/sickcodes/Docker-OSX/
@@ -97,6 +101,26 @@ while (( "$#" )); do
                 shift
             ;;
 
+    --width=* )
+                export WIDTH="${1#*=}"
+                shift
+            ;;
+    --width* )
+                export WIDTH="${2}"
+                shift
+                shift
+            ;;
+
+    --height=* )
+                export HEIGHT="${1#*=}"
+                shift
+            ;;
+    --height* )
+                export HEIGHT="${2}"
+                shift
+                shift
+            ;;
+
     --output-bootdisk=* )
                 export OUTPUT_QCOW="${1#*=}"
                 shift
@@ -153,6 +177,8 @@ generate_bootdisk () {
             -e s/{{BOARD_SERIAL}}/"${BOARD_SERIAL}"/g \
             -e s/{{UUID}}/"${UUID}"/g \
             -e s/{{ROM}}/"${ROM}"/g \
+            -e s/{{WIDTH}}/"${WIDTH:-1920}"/g \
+            -e s/{{HEIGHT}}/"${HEIGHT:-1080}"/g \
             "${PLIST_MASTER}" > ./tmp.config.plist || exit 1
     else
         cat <<EOF
@@ -163,6 +189,9 @@ Error: one of the following values is missing:
 --board-serial "${BOARD_SERIAL:-MISSING}"
 --uuid "${UUID:-MISSING}"
 --mac-address "${MAC_ADDRESS:-MISSING}"
+
+--width "${WIDTH:-1920}"
+--height "${HEIGHT:-1080}"
 
 EOF
         exit 1

--- a/custom/generate-unique-machine-values.sh
+++ b/custom/generate-unique-machine-values.sh
@@ -250,11 +250,11 @@ generate_serial_sets () {
     elif [[ "${MASTER_PLIST}" ]] && [[ "${MASTER_PLIST_URL}" ]]; then
         echo 'You specified both a custom plist file AND a custom plist url. Use one or the other.'
     elif [[ "${MASTER_PLIST_URL}" ]]; then
-        wget -o "./${MASTER_PLIST:=/config-custom.plist}" "${MASTER_PLIST_URL}" \
+        wget -O "./${MASTER_PLIST:=/config-custom.plist}" "${MASTER_PLIST_URL}" \
             || echo "Could not download ${MASTER_PLIST_URL}" && exit 1
     else
         MASTER_PLIST_URL='https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/custom/config-nopicker-custom.plist'
-        wget -o "./${MASTER_PLIST:=/config-nopicker-custom.plist}" "${MASTER_PLIST_URL}" \
+        wget -O "./${MASTER_PLIST:=/config-nopicker-custom.plist}" "${MASTER_PLIST_URL}" \
             || echo "Could not download ${MASTER_PLIST_URL}" && exit 1
     fi
 

--- a/custom/generate-unique-machine-values.sh
+++ b/custom/generate-unique-machine-values.sh
@@ -251,11 +251,11 @@ generate_serial_sets () {
         echo 'You specified both a custom plist file AND a custom plist url. Use one or the other.'
     elif [[ "${MASTER_PLIST_URL}" ]]; then
         wget -O "${MASTER_PLIST:=./config-custom.plist}" "${MASTER_PLIST_URL}" \
-            || echo "Could not download ${MASTER_PLIST_URL}" && exit 1
+            || { echo "Could not download ${MASTER_PLIST_URL}" && exit 1 ; }
     else
         MASTER_PLIST_URL='https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/custom/config-nopicker-custom.plist'
         wget -O "${MASTER_PLIST:=./config-nopicker-custom.plist}" "${MASTER_PLIST_URL}" \
-            || echo "Could not download ${MASTER_PLIST_URL}" && exit 1
+            || { echo "Could not download ${MASTER_PLIST_URL}" && exit 1 ; }
     fi
 
     [[ -e ./opencore-image-ng.sh ]] || wget https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/custom/opencore-image-ng.sh && chmod +x opencore-image-ng.sh

--- a/custom/generate-unique-machine-values.sh
+++ b/custom/generate-unique-machine-values.sh
@@ -21,6 +21,8 @@ General options:
     --output-bootdisk <filename>    Optionally change the bootdisk qcow output filename. Useless when count > 1.
     --output-env <filename>         Optionally change the bootdisk env filename. Useless when count > 1.
     --output-dir <directory>        Optionally change the script output location.
+    --width <string>                Resolution x axis length in pixels (default 1920)
+    --height <string>               Resolution y axis length in pixels (default 1080
 
     --help, -h, help                Display this help and exit
     --plists                        Create corresponding config.plists for each serial set.
@@ -132,6 +134,27 @@ while (( "$#" )); do
                 shift
             ;;
 
+    --width=* )
+                export WIDTH="${1#*=}"
+                shift
+            ;;
+
+    --width* )
+                export WIDTH="${2}"
+                shift
+                shift
+            ;;
+
+    --height=* )
+                export HEIGHT="${1#*=}"
+                shift
+            ;;
+    --height* )
+                export HEIGHT="${2}"
+                shift
+                shift
+            ;;
+
     --plists )
                 export CREATE_PLISTS=1
                 shift
@@ -231,6 +254,8 @@ export SERIAL="${SERIAL}"
 export BOARD_SERIAL="${BOARD_SERIAL}"
 export UUID="${UUID}"
 export MAC_ADDRESS="${MAC_ADDRESS}"
+export WIDTH="${WIDTH:=1920}"
+export HEIGHT="${HEIGHT:=1080}"
 EOF
 
             # plist required for bootdisks, so create anyway.
@@ -244,6 +269,8 @@ EOF
                     -e s/{{BOARD_SERIAL}}/"${BOARD_SERIAL}"/g \
                     -e s/{{UUID}}/"${UUID}"/g \
                     -e s/{{ROM}}/"${ROM}"/g \
+                    -e s/{{WIDTH}}/"${WIDTH}"/g \
+                    -e s/{{HEIGHT}}/"${HEIGHT}"/g \
                     "${PLIST_MASTER}" > "${OUTPUT_DIRECTORY}/plists/${SERIAL}.config.plist" || exit 1
             fi
 

--- a/custom/generate-unique-machine-values.sh
+++ b/custom/generate-unique-machine-values.sh
@@ -250,11 +250,11 @@ generate_serial_sets () {
     elif [[ "${MASTER_PLIST}" ]] && [[ "${MASTER_PLIST_URL}" ]]; then
         echo 'You specified both a custom plist file AND a custom plist url. Use one or the other.'
     elif [[ "${MASTER_PLIST_URL}" ]]; then
-        wget -O "./${MASTER_PLIST:=/config-custom.plist}" "${MASTER_PLIST_URL}" \
+        wget -O "${MASTER_PLIST:=./config-custom.plist}" "${MASTER_PLIST_URL}" \
             || echo "Could not download ${MASTER_PLIST_URL}" && exit 1
     else
         MASTER_PLIST_URL='https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/custom/config-nopicker-custom.plist'
-        wget -O "./${MASTER_PLIST:=/config-nopicker-custom.plist}" "${MASTER_PLIST_URL}" \
+        wget -O "${MASTER_PLIST:=./config-nopicker-custom.plist}" "${MASTER_PLIST_URL}" \
             || echo "Could not download ${MASTER_PLIST_URL}" && exit 1
     fi
 

--- a/custom/generate-unique-machine-values.sh
+++ b/custom/generate-unique-machine-values.sh
@@ -247,9 +247,9 @@ generate_serial_sets () {
 
     if [[ "${MASTER_PLIST}" ]]; then
         [[ -e "${MASTER_PLIST}" ]] || echo "Could not find: ${MASTER_PLIST}"
-    elif [[ "${MASTER_PLIST}" ]] && [[ "${MASTER_PLIST_URL}" ]];
+    elif [[ "${MASTER_PLIST}" ]] && [[ "${MASTER_PLIST_URL}" ]]; then
         echo 'You specified both a custom plist file AND a custom plist url. Use one or the other.'
-    elif [[ "${MASTER_PLIST_URL}" ]];
+    elif [[ "${MASTER_PLIST_URL}" ]]; then
         wget -o "./${MASTER_PLIST:=/config-custom.plist}" "${MASTER_PLIST_URL}" \
             || echo "Could not download ${MASTER_PLIST_URL}" && exit 1
     else


### PR DESCRIPTION
Example:

```bash
stat mac_hdd_ng.img # make sure you have an image if you're using :naked
touch ./mynewbootdisk.qcow

docker run -it \
    --device /dev/kvm \
    -e "DISPLAY=${DISPLAY:-:0.0}" \
    -v /tmp/.X11-unix:/tmp/.X11-unix \
    -p 50922:10022 \
    -e NOPICKER=true \
    -e GENERATE_SPECIFIC=true \
    -e DEVICE_MODEL="iMacPro1,1" \
    -e SERIAL="C02TW0WAHX87" \
    -e BOARD_SERIAL="C027251024NJG36UE" \
    -e UUID="5CCB366D-9118-4C61-A00A-E5BAF3BED451" \
    -e MAC_ADDRESS="A8:5C:2C:9A:46:2F" \
    -e WIDTH=1000 \
    -e HEIGHT=1000 \
    -e BOOTDISK=/bootdisk \
    -v "${PWD}/mynewbootdisk.qcow:/bootdisk" \
    -v "${PWD}/mac_hdd_ng.img:/image" \
    sickcodes/docker-osx:naked
```