### PR TITLE
Propose RAM default to 2G instead of 8G

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -213,7 +213,7 @@ RUN touch Launch.sh \
     && tee -a Launch.sh <<< 'set -eu' \
     && tee -a Launch.sh <<< 'sudo chown    $(id -u):$(id -g) /dev/kvm 2>/dev/null || true' \
     && tee -a Launch.sh <<< 'sudo chown -R $(id -u):$(id -g) /dev/snd 2>/dev/null || true' \
-    && tee -a Launch.sh <<< 'exec qemu-system-x86_64 -m ${RAM:-8}000 \' \
+    && tee -a Launch.sh <<< 'exec qemu-system-x86_64 -m ${RAM:-2}000 \' \
     && tee -a Launch.sh <<< '-cpu Penryn,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+pcid,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check \' \
     && tee -a Launch.sh <<< '-machine q35,accel=kvm:tcg \' \
     && tee -a Launch.sh <<< '-smp ${CPU_STRING:-${SMP:-4},cores=${CORES:-4}} \' \


### PR DESCRIPTION
Fixes https://github.com/sickcodes/Docker-OSX/issues/188#issue-831137065

I'm not sure if this is a new bug but it's the first time I've seen it, after reading @C9-Dev's comment:

https://github.com/sickcodes/Docker-OSX/issues/131#issuecomment-798802122

This PR changes default RAM to 2000 which is the minimum.

Perhaps in addition, I could add

```dockerfile
-e RAM=auto \
```
This would only be for blind machines... as most users tend to know how much RAM they have, or their server has already.
```bash
RAM=${RAM:-$(("$(head -n1 /proc/meminfo | tr -dc '[:digit:]') / 900000"))}000 \
exec qemu-system-x86_64 -m ${RAM} \
```