### PR TITLE
4.2 Switch to using custom-plist at runtime. Allow -v `-v plist:/plis…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 |Version|Date|Notes|
 |---|---|---|
+|4.2|2021-03-15|No longer use static qcow2 bootdisks. Create at runtime. Supply own with `-v plist:/plist` plus `-e MASTER_PLIST=/plist` or `-e MASTER_PLIST_URL=https://raw.githubusercontent.com/sickcodes/osx-serial-generator/master/config-nopicker-custom.plist`|
+|   |2021-03-14|Change default RAM to 2G|
+|   |2021-03-09|Add https://github.com/sickcodes/osx-serial-generator.git as a submodule to replace ./custom|
 |   |2021-03-06|Change envs to require --envs. Automatically enable --envs if --output-env is used. Same for plists, bootdisks. Fix help ugliness and sanity of generate serial scripts. Fix bootdisk not getting written to persistent file when using NOPICKER=true. NOPICKER=true is overridden by a custom plist now anyway. Remove useless case statements. Allow -e HEADLESS=true as human readable alternative to -e DISPLAY=:99.|
 |4.1|2021-03-04|Add `-e MASTER_PLIST_URL` to all images to allow using your own remote plist.|
 |   |2021-03-03|Add `WIDTH` and `HEIGHT` to set the x and y resolutions, use in conjuction with serial numbers.|

--- a/Dockerfile.auto
+++ b/Dockerfile.auto
@@ -7,7 +7,7 @@
 # 
 # Title:            Docker-OSX (Mac on Docker)
 # Author:           Sick.Codes https://twitter.com/sickcodes
-# Version:          4.1
+# Version:          4.2
 # License:          GPLv3+
 # Repository:       https://github.com/sickcodes/Docker-OSX
 # Website:          https://sick.codes
@@ -141,9 +141,17 @@ ENV IMAGE_PATH=/home/arch/OSX-KVM/mac_hdd_ng.img
 
 ENV NOPICKER=true
 
+# The x and y coordinates for resolution.
+# Must be used with either -e GENERATE_UNIQUE=true or -e GENERATE_SPECIFIC=true.
+ENV WIDTH=1920
+ENV HEIGHT=1080
+
+ENV MASTER_PLIST_URL=
+ENV MASTER_PLIST=./Docker-OSX/osx-serial-generator/config-nopicker-custom.plist
+
 ENV TERMS_OF_USE=i_agree
 
-ENV BOILERPLATE="By using this Dockerfile, you hereby agree that you are a security reseacher or developer and agree to use this Dockerfile to make the world a safer place. Examples include: making your apps safer, finding your mobile phone, compiling security products, etc. You understand that Docker-OSX is an Open Source project, which is released to the public under the GNU Pulic License version 3 and above. You acknowledge that the Open Source project is absolutely unaffiliated with any third party, in any form whatsoever. Any trademarks or intelectual property which happen to be mentioned anywhere in or around the project are owned by their respective owners. By using this Dockerfile, you agree to agree to the EULA of each piece of upstream or downstream software. The following code is released for the sole purpose of security research, under the GNU Public License version 3. If you are concerned about the licensing, please note that this project is not AGPL. A copy of the license is available online: https://github.com/sickcodes/Docker-OSX/blob/master/LICENSE. In order to use the following Dockerfile you must read and understand the terms. Once you have read the terms, use the -e TERMS_OF_USE=i_agree or -e TERMS_OF_USE=i_disagree"
+ENV BOILERPLATE="By using this Dockerfile, you hereby agree that you are a security reseacher or developer and agree to use this Dockerfile to make the world a safer place. Examples include: making your apps safer, finding your mobile phone, compiling security products, etc. You understand that Docker-OSX is an Open Source project, which is released to the public under the GNU Pulic License version 3 and above. You acknowledge that the Open Source project is absolutely unaffiliated with any third party, in any form whatsoever. Any trademarks or intelectual property which happen to be mentioned anywhere in or around the project are owned by their respective owners. By using this Dockerfile, you agree to agree to the EULA of each piece of upstream or downstream software. The following code is released for the sole purpose of security research, under the GNU Public License version 3. If you are concerned about the licensing, please note that this project is not AGPL. A copy of the license is available online: https://github.com/sickcodes/Docker-OSX/blob/master/LICENSE. In order to use the following Dockerfile you must read and understand the terms."
 
 CMD echo "${BOILERPLATE}" \
     ; [[ "${TERMS_OF_USE}" = i_agree ]] || exit 1 \
@@ -152,12 +160,13 @@ CMD echo "${BOILERPLATE}" \
     ; sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" || true \
     ; [[ "${NOPICKER}" == true ]] && { \
         sed -i '/^.*InstallMedia.*/d' Launch.sh \
-        && export BOOTDISK="${BOOTDISK:=/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore-nopicker.qcow2}" \
+        && export MASTER_PLIST="${MASTER_PLIST:-./Docker-OSX/osx-serial-generator/config-nopicker-custom.plist}" \
     ; } \
-    || export BOOTDISK="${BOOTDISK:=/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" \
+    || export MASTER_PLIST="${MASTER_PLIST:-./Docker-OSX/osx-serial-generator/config-custom.plist}" \
+    ; [[ "${MASTER_PLIST_URL}" ]] && wget -O "${MASTER_PLIST}" "${MASTER_PLIST_URL}" \
     ; [[ "${GENERATE_UNIQUE}" == true ]] && { \
         ./Docker-OSX/osx-serial-generator/generate-unique-machine-values.sh \
-            --master-plist-url="${MASTER_PLIST_URL}" \
+            --master-plist="${MASTER_PLIST}" \
             --count 1 \
             --tsv ./serial.tsv \
             --bootdisks \
@@ -169,7 +178,7 @@ CMD echo "${BOILERPLATE}" \
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
             source "${ENV:=/env}" 2>/dev/null \
             ; ./Docker-OSX/osx-serial-generator/generate-specific-bootdisk.sh \
-            --master-plist-url="${MASTER_PLIST_URL}" \
+            --master-plist="${MASTER_PLIST}" \
             --model "${DEVICE_MODEL}" \
             --serial "${SERIAL}" \
             --board-serial "${BOARD_SERIAL}" \

--- a/Dockerfile.naked
+++ b/Dockerfile.naked
@@ -7,7 +7,7 @@
 # 
 # Title:            Docker-OSX (Mac on Docker)
 # Author:           Sick.Codes https://twitter.com/sickcodes
-# Version:          4.1
+# Version:          4.2
 # License:          GPLv3+
 # Repository:       https://github.com/sickcodes/Docker-OSX
 # Website:          https://sick.codes
@@ -114,6 +114,14 @@ ENV IMAGE_PATH=/image
 
 ENV NOPICKER=true
 
+# The x and y coordinates for resolution.
+# Must be used with either -e GENERATE_UNIQUE=true or -e GENERATE_SPECIFIC=true.
+ENV WIDTH=1920
+ENV HEIGHT=1080
+
+ENV MASTER_PLIST_URL=
+ENV MASTER_PLIST=./Docker-OSX/osx-serial-generator/config-nopicker-custom.plist
+
 CMD sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" || true \
     ; sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" || true \
     ; { [[ "${DISPLAY}" = ':99' ]] || [[ "${HEADLESS}" == true ]] ; } && { \
@@ -122,12 +130,13 @@ CMD sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" || true 
     ; } \
     ; [[ "${NOPICKER}" == true ]] && { \
         sed -i '/^.*InstallMedia.*/d' Launch.sh \
-        && export BOOTDISK="${BOOTDISK:=/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore-nopicker.qcow2}" \
+        && export MASTER_PLIST="${MASTER_PLIST:-./Docker-OSX/osx-serial-generator/config-nopicker-custom.plist}" \
     ; } \
-    || export BOOTDISK="${BOOTDISK:=/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" \
+    || export MASTER_PLIST="${MASTER_PLIST:-./Docker-OSX/osx-serial-generator/config-custom.plist}" \
+    ; [[ "${MASTER_PLIST_URL}" ]] && wget -O "${MASTER_PLIST}" "${MASTER_PLIST_URL}" \
     ; [[ "${GENERATE_UNIQUE}" == true ]] && { \
         ./Docker-OSX/osx-serial-generator/generate-unique-machine-values.sh \
-            --master-plist-url="${MASTER_PLIST_URL}" \
+            --master-plist="${MASTER_PLIST}" \
             --count 1 \
             --tsv ./serial.tsv \
             --bootdisks \
@@ -139,7 +148,7 @@ CMD sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" || true 
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
             source "${ENV:=/env}" 2>/dev/null \
             ; ./Docker-OSX/osx-serial-generator/generate-specific-bootdisk.sh \
-            --master-plist-url="${MASTER_PLIST_URL}" \
+            --master-plist="${MASTER_PLIST}" \
             --model "${DEVICE_MODEL}" \
             --serial "${SERIAL}" \
             --board-serial "${BOARD_SERIAL}" \


### PR DESCRIPTION
4.2 Switch to using custom-plist at runtime. Allow -v `-v plist:/plist` plus `-e MASTER_PLIST=/plist` or `-e MASTER_PLIST_URL=https://raw.githubusercontent.com/sickcodes/osx-serial-generator/master/config-nopicker-custom.plist`

As currently it was an online-only plist.

Example
```bash

docker run -it \
    --device /dev/kvm \
    -e "DISPLAY=${DISPLAY:-:0.0}" \
    -v /tmp/.X11-unix:/tmp/.X11-unix \
    -e RAM=20 \
    -p 50922:10022 \
    -e GENERATE_SPECIFIC=true \
    -e DEVICE_MODEL="${DEVICE_MODEL}" \
    -e SERIAL="${SERIAL}" \
    -e BOARD_SERIAL="${BOARD_SERIAL}" \
    -e UUID="${UUID}" \
    -e MAC_ADDRESS="${MAC_ADDRESS}" \
    -v "${IMAGE_NAME}":/image \
    -e WIDTH=1600 \
    -e HEIGHT=900 \
    -e MASTER_PLIST='/plist' \
    -v "${PWD}/config-nopicker-custom.plist:/plist" \
    docker-osx:latest 
```