### PR TITLE
IMAGE_FORMAT=qcow2, KVM= 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 |Version|Date|Notes|
 |---|---|---|
+|4.2|2021-03-24|Add all ENV variables to each dockerfile for readability. Add RAM allocation buffer and cache drop bug fix. Add kvm and libvirt groups. Add `IMAGE_FORMAT=qcow2` to allow `IMAGE_FORMAT=raw` too.|
+|   |2021-03-19|Use RAM=3 as the default RAM allocation. Add instructions to clear buff/cache.|
 |   |2021-03-17|Add RAM=max and RAM=half to dynamically select ram at runtime (DEFAULT).|
 |   |2021-03-06|Change envs to require --envs. Automatically enable --envs if --output-env is used. Same for plists, bootdisks. Fix help ugliness and sanity of generate serial scripts. Fix bootdisk not getting written to persistent file when using NOPICKER=true. NOPICKER=true is overridden by a custom plist now anyway. Remove useless case statements. Allow -e HEADLESS=true as human readable alternative to -e DISPLAY=:99.|
 |4.1|2021-03-04|Add `-e MASTER_PLIST_URL` to all images to allow using your own remote plist.|

--- a/Dockerfile
+++ b/Dockerfile
@@ -214,7 +214,7 @@ RUN touch Launch.sh \
     && tee -a Launch.sh <<< 'sudo chown -R $(id -u):$(id -g) /dev/snd 2>/dev/null || true' \
     && tee -a Launch.sh <<< 'exec qemu-system-x86_64 -m ${RAM:-2}000 \' \
     && tee -a Launch.sh <<< '-cpu Penryn,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+pcid,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check \' \
-    && tee -a Launch.sh <<< '-machine q35,${KVM:-"accel=kvm:tcg"} \' \
+    && tee -a Launch.sh <<< '-machine q35,${KVM-"accel=kvm:tcg"} \' \
     && tee -a Launch.sh <<< '-smp ${CPU_STRING:-${SMP:-4},cores=${CORES:-4}} \' \
     && tee -a Launch.sh <<< '-usb -device usb-kbd -device usb-tablet \' \
     && tee -a Launch.sh <<< '-device isa-applesmc,osk=ourhardworkbythesewordsguardedpleasedontsteal\(c\)AppleComputerInc \' \

--- a/Dockerfile.auto
+++ b/Dockerfile.auto
@@ -7,7 +7,7 @@
 # 
 # Title:            Docker-OSX (Mac on Docker)
 # Author:           Sick.Codes https://twitter.com/sickcodes
-# Version:          4.1
+# Version:          4.2
 # License:          GPLv3+
 # Repository:       https://github.com/sickcodes/Docker-OSX
 # Website:          https://sick.codes
@@ -115,19 +115,24 @@ RUN mkdir -p ~/.ssh \
 
 ARG COMPLETE=true
 
-# Feel free to take a copy of this image and then host it internally
-ARG IMAGE_URL='https://images2.sick.codes/mac_hdd_ng_auto.img'
-
 # use the COMPLETE arg, for a complete image, ready to boot.
 # otherwise use your own image: -v "$PWD/disk.img":/image
 ARG WGET_OPTIONS=
 # ARG WGET_OPTIONS='--no-verbose'
 
+# Feel free to take a copy of this image and then host it internally
+ARG IMAGE_URL='https://images.sick.codes/mac_hdd_ng_auto.img'
+# ARG IMAGE_URL='https://images.sick.codes/mac_hdd_ng_auto_big_sur.img'
+
 RUN if [[ "${COMPLETE}" ]]; then \
-        echo "Downloading 20GB+ image... This step might take a while... Press Ctrl+C if you want to abort." \
+        echo "Downloading 20GB image... This step might take a while... Press Ctrl+C if you want to abort." \
         ; rm -f /home/arch/OSX-KVM/mac_hdd_ng.img \
         && wget ${WGET_OPTIONS} -O /home/arch/OSX-KVM/mac_hdd_ng.img "${IMAGE_URL}" \
     ; fi
+
+#### SPECIAL RUNTIME ARGUMENTS BELOW
+
+ENV ADDITIONAL_PORTS=
 
 ENV BOOTDISK=
 
@@ -137,9 +142,33 @@ ENV HEADLESS=false
 
 ENV ENV=/env
 
+# Boolean for generating a bootdisk with new random serials.
+ENV GENERATE_UNIQUE=false
+
+# Boolean for generating a bootdisk with specific serials.
+ENV GENERATE_SPECIFIC=false
+
 ENV IMAGE_PATH=/home/arch/OSX-KVM/mac_hdd_ng.img
+ENV IMAGE_FORMAT=qcow2
+
+ENV KVM='accel=kvm:tcg'
+
+# ENV MASTER_PLIST_URL="https://raw.githubusercontent.com/sickcodes/osx-serial-generator/master/config-custom.plist"
+
+# ENV NETWORKING=e1000-82545em
+ENV NETWORKING=vmxnet3
 
 ENV NOPICKER=true
+
+# dynamic RAM options for runtime
+ENV RAM=3
+# ENV RAM=max
+# ENV RAM=half
+
+# The x and y coordinates for resolution.
+# Must be used with either -e GENERATE_UNIQUE=true or -e GENERATE_SPECIFIC=true.
+ENV WIDTH=1920
+ENV HEIGHT=1080
 
 ENV TERMS_OF_USE=i_agree
 

--- a/Dockerfile.naked
+++ b/Dockerfile.naked
@@ -7,7 +7,7 @@
 # 
 # Title:            Docker-OSX (Mac on Docker)
 # Author:           Sick.Codes https://twitter.com/sickcodes
-# Version:          4.1
+# Version:          4.2
 # License:          GPLv3+
 # Repository:       https://github.com/sickcodes/Docker-OSX
 # Website:          https://sick.codes
@@ -102,6 +102,10 @@ RUN mkdir -p ~/.ssh \
     && tee -a ~/.ssh/config <<< '    StrictHostKeyChecking no' \
     && tee -a ~/.ssh/config <<< '    UserKnownHostsFile=/dev/null'
 
+#### SPECIAL RUNTIME ARGUMENTS BELOW
+
+ENV ADDITIONAL_PORTS=
+
 ENV BOOTDISK=
 
 ENV DISPLAY=:99
@@ -110,9 +114,33 @@ ENV HEADLESS=false
 
 ENV ENV=/env
 
+# Boolean for generating a bootdisk with new random serials.
+ENV GENERATE_UNIQUE=false
+
+# Boolean for generating a bootdisk with specific serials.
+ENV GENERATE_SPECIFIC=false
+
 ENV IMAGE_PATH=/image
+ENV IMAGE_FORMAT=qcow2
+
+ENV KVM='accel=kvm:tcg'
+
+# ENV MASTER_PLIST_URL="https://raw.githubusercontent.com/sickcodes/osx-serial-generator/master/config-custom.plist"
+
+# ENV NETWORKING=e1000-82545em
+ENV NETWORKING=vmxnet3
 
 ENV NOPICKER=true
+
+# dynamic RAM options for runtime
+ENV RAM=3
+# ENV RAM=max
+# ENV RAM=half
+
+# The x and y coordinates for resolution.
+# Must be used with either -e GENERATE_UNIQUE=true or -e GENERATE_SPECIFIC=true.
+ENV WIDTH=1920
+ENV HEIGHT=1080
 
 CMD sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" || true \
     ; sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" || true \


### PR DESCRIPTION
…ocation buffer and cache drop bug fix. Add kvm and libvirt groups. Add IMAGE_FORMAT=qcow2 to allow IMAGE_FORMAT=raw too.


Add all ENV variables to each dockerfile for readability.

```
#default
-e IMAGE_FORMAT=qcow2
```
```
# allows raw APFS images to be used:
-e IMAGE_FORMAT=raw
```

```
#default
-e KVM='accel=kvm:tcg'
```
```
# should run without KVM
-e KVM=
```


Add note about dropping dedotated wam:
```bash
sudo tee /proc/sys/vm/drop_caches <<< 3
```