### PR TITLE
Remove envsubst to allow interactive QEMU using -i

### DIFF
--- a/Dockerfile.auto
+++ b/Dockerfile.auto
@@ -219,7 +219,7 @@ CMD echo "${BOILERPLATE}" \
         /usr/bin/ssh-keygen -t rsa -f ~/.ssh/id_docker_osx -q -N "" \
         && chmod 600 ~/.ssh/id_docker_osx \
     ; } \
-    ; envsubst < ./Launch.sh | bash \
+    ; /bin/bash -c ./Launch.sh \
     & echo "Booting Docker-OSX in the background. Please wait..." \
     ; until [[ "$(sshpass -palpine ssh-copy-id -f -i ~/.ssh/id_docker_osx.pub -p 10022 user@127.0.0.1)" ]]; do \
         echo "Disk is being copied between layers. Repeating until able to copy SSH key into OSX..." \

--- a/Dockerfile.naked
+++ b/Dockerfile.naked
@@ -177,4 +177,4 @@ CMD sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" || true 
             --height "${HEIGHT:-1080}" \
             --output-bootdisk "${BOOTDISK:=/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" \
     ; } \
-    ; ./enable-ssh.sh && envsubst < ./Launch.sh | bash
+    ; ./enable-ssh.sh && /bin/bash -c ./Launch.sh


### PR DESCRIPTION
Won't work on :auto because more commands happen