### PR TITLE
README / troubleshooting docs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ If you like this project, consider contributing here or upstream!
 
 ## Quick Start Docker-OSX
 
+First time here? try [initial setup](#initial-setup), otherwise try the instructions below to use either Catalina or Big Sur.
+
 ### Catalina [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/latest?label=sickcodes%2Fdocker-osx%3Alatest](https://img.shields.io/docker/image-size/sickcodes/docker-osx/latest?label=sickcodes%2Fdocker-osx%3Alatest)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
 
 ```bash
@@ -43,7 +45,7 @@ docker run -it \
 
 ## Technical details
 
-There currently four images, each with different use cases (explained [below](https://github.com/sickcodes/Docker-OSX#container-images)):
+There currently four images, each with different use cases (explained [below](#container-images)):
 
 [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/latest?label=sickcodes%2Fdocker-osx%3Alatest](https://img.shields.io/docker/image-size/sickcodes/docker-osx/latest?label=sickcodes%2Fdocker-osx%3Alatest)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
 
@@ -53,8 +55,9 @@ There currently four images, each with different use cases (explained [below](ht
 
 [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/auto?label=sickcodes%2Fdocker-osx%3Aauto](https://img.shields.io/docker/image-size/sickcodes/docker-osx/auto?label=sickcodes%2Fdocker-osx%3Aauto)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
 
-The images (excluding `:naked`) launch a container with an existing installation with a couple of premade configurations. This special image was developed by [Sick.Codes](https://sick.codes):
+This special set of images was developed by [Sick.Codes](https://sick.codes).
 
+The images (excluding `:naked`) launch a container with an existing installation with a couple of premade configurations:
 - username: `user`, password: `alpine`
 - SSH enabled (`localhost:50922`)
 - VNC enabled (`localhost:8888`) if using ./vnc version
@@ -83,7 +86,7 @@ The images (excluding `:naked`) launch a container with an existing installation
 
 Images built on top of the contents of this repository are also available on **Docker Hub** for convenience: https://hub.docker.com/r/sickcodes/docker-osx
 
-A comprehensive list of the available Docker images and their intended purpose can be found in the [Instructions](README.md#Instructions).
+A comprehensive list of the available Docker images and their intended purpose can be found in the [Instructions](#instructions).
 
 ## Kubernetes
 
@@ -103,7 +106,7 @@ Feel free to open an [issue](https://github.com/sickcodes/Docker-OSX/issues/new/
 
 #### Resolved issues
 
-Before you open an issue, however, please check the [closed issues](https://github.com/sickcodes/Docker-OSX/issues?q=is%3Aissue+is%3Aclosed) and confirm that you're using the latest version of this repository — your issues may have already been resolved! You might also see your answer in our questions and answers section [below](https://github.com/sickcodes/Docker-OSX#more-questions-and-answers).
+Before you open an issue, however, please check the [closed issues](https://github.com/sickcodes/Docker-OSX/issues?q=is%3Aissue+is%3Aclosed) and confirm that you're using the latest version of this repository — your issues may have already been resolved! You might also see your answer in our questions and answers section [below](#more-questions-and-answers).
 
 ### Feature requests and updates
 
@@ -129,7 +132,7 @@ Docker-OSX is licensed under the [GPL v3+](LICENSE). Contributions are welcomed 
 
 ## Disclaimer
 
-If you are serious about Apple Security, and possibly finding 6-figure bug bounties within the Apple Bug Bounty Program, then you're in the right place! Further notes: [Is Hackintosh, OSX-KVM, or Docker-OSX legal?](https://sick.codes/is-hackintosh-osx-kvm-or-docker-osx-legal/).
+If you are serious about Apple Security, and possibly finding 6-figure bug bounties within the Apple Bug Bounty Program, then you're in the right place! Further notes: [Is Hackintosh, OSX-KVM, or Docker-OSX legal?](https://sick.codes/is-hackintosh-osx-kvm-or-docker-osx-legal/)
 
 Product names, logos, brands and other trademarks referred to within this project are the property of their respective trademark holders. These trademark holders are not affiliated with our repository in any capacity. They do not sponsor or endorse this project in any way.
 
@@ -137,19 +140,19 @@ Product names, logos, brands and other trademarks referred to within this projec
 
 ## Container images
 
-### Already set up or just looking to make a container quickly? Check out our [container creation examples](https://github.com/sickcodes/Docker-OSX#container-creation-examples) section.
+### Already set up or just looking to make a container quickly? Check out our [quick start](#quick-start-docker-osx) or see a bunch more use cases under our [container creation examples](#container-creation-examples) section.
 
-There are several different Docker images available, which are suitable for different purposes.
+There are several different Docker-OSX images available which are suitable for different purposes.
 
-- `sickcodes/docker-osx:latest` - [I just want to try it out.](https://github.com/sickcodes/Docker-OSX#quick-start-large-pre-made-image)
-- `sickcodes/docker-osx:latest` - [I want to use Docker-OSX to develop/secure apps in Xcode (sign into Xcode, Transporter)](https://github.com/sickcodes/Docker-OSX#basic-quick-start-docker-osx)
-- `sickcodes/docker-osx:naked` - [I want to use Docker-OSX for CI/CD-related purposes (sign into Xcode, Transporter)](https://github.com/sickcodes/Docker-OSX#fully-headless-using-my-own-image-for-cicd)
+- `sickcodes/docker-osx:latest` - [I just want to try it out.](#quick-start-docker-osx)
+- `sickcodes/docker-osx:latest` - [I want to use Docker-OSX to develop/secure apps in Xcode (sign into Xcode, Transporter)](#quick-start-your-own-image-naked-container-image)
+- `sickcodes/docker-osx:naked` - [I want to use Docker-OSX for CI/CD-related purposes (sign into Xcode, Transporter)](#building-a-headless-container-from-a-custom-image)
 
 Create your personal image using `:latest`. Then, extract the image. Afterwards, you will be able to duplicate that image and import it to the `:naked` container, in order to revert the container to a previous state repeatedly.
 
-- `sickcodes/docker-osx:auto` - [I'm only interested in using the command line. (Useful for compiling software or using Homebrew headlessly).](https://github.com/sickcodes/Docker-OSX#pre-built-image-arbitrary-command-line-arguments)
-- `sickcodes/docker-osx:naked` - [I need iMessage/iCloud for security research.](https://github.com/sickcodes/Docker-OSX#generating-serial-numbers)
-- `sickcodes/docker-osx:big-sur` - [I want to run Big Sur.](https://github.com/sickcodes/Docker-OSX#technical-details)
+- `sickcodes/docker-osx:auto` - [I'm only interested in using the command line (useful for compiling software or using Homebrew headlessly).](#prebuilt-image-with-arbitrary-command-line-arguments)
+- `sickcodes/docker-osx:naked` - [I need iMessage/iCloud for security research.](#generating-serial-numbers)
+- `sickcodes/docker-osx:big-sur` - [I want to run Big Sur.](#quick-start-docker-osx)
 
 ## Initial setup
 Before you do anything else, you will need to turn on hardware virtualization in your BIOS. Precisely how will depend on your particular machine (and BIOS), but it should be straightforward.
@@ -178,7 +181,7 @@ echo 1 | sudo tee /sys/module/kvm/parameters/ignore_msrs
 sudo modprobe kvm
 ```
 
-## Additional boot instructions for when you are [creating your container](https://github.com/sickcodes/Docker-OSX#container-creation-examples)
+## Additional boot instructions for when you are [creating your container](#container-creation-examples)
 
 - Boot the macOS Base System
 
@@ -197,13 +200,13 @@ sudo modprobe kvm
 
 This is a great place to start if you are having trouble getting going, especially if you're not that familiar with Docker just yet.
 
-Just looking to make a container quickly? Check out our [container creation examples](https://github.com/sickcodes/Docker-OSX#container-creation-examples) section.
+Just looking to make a container quickly? Check out our [container creation examples](#container-creation-examples) section.
 
-More specific/advanced troubleshooting questions and answers may be found in [More Questions and Answers](https://github.com/sickcodes/Docker-OSX#more-questions-and-answers). You should also check out the [closed issues](https://github.com/sickcodes/Docker-OSX/issues?q=is%3Aissue+is%3Aclosed). Someone else might have gotten a question like yours answered already even if you can't find it in this document!
+More specific/advanced troubleshooting questions and answers may be found in [More Questions and Answers](#more-questions-and-answers). You should also check out the [closed issues](https://github.com/sickcodes/Docker-OSX/issues?q=is%3Aissue+is%3Aclosed). Someone else might have gotten a question like yours answered already even if you can't find it in this document!
 
 #### Confirm that your CPU supports virtualization
 
-See [initial setup](https://github.com/sickcodes/Docker-OSX#initial-setup).
+See [initial setup](#initial-setup).
 
 #### Confirm your user is part of the the Docker group, KVM group, libvirt group
 
@@ -220,7 +223,7 @@ sudo usermod -aG libvirt "${USER}"
 sudo usermod -aG kvm "${USER}"
 ```
 
-See also: [initial setup](https://github.com/sickcodes/Docker-OSX#initial-setup).
+See also: [initial setup](#initial-setup).
 
 #### Is the docker daemon enabled?
 
@@ -294,7 +297,7 @@ See also: [here](https://github.com/sickcodes/Docker-OSX/issues/174).
 
 Created a container with `docker run` and want to reuse the underlying image again later? 
 
-See [container creation examples](https://github.com/sickcodes/Docker-OSX#container-creation-examples) for how to get to the point where this is applicable.
+NB: see [container creation examples](#container-creation-examples) first for how to get to the point where this is applicable.
 
 This is for when you want to run the SAME container again later. You may need to use `docker commit` to save your container before you can reuse it. Check if your container is persisted with `docker ps --all`.
 
@@ -332,7 +335,7 @@ docker start -ai -i <Replace this with your ID>
 
 ### LibGTK errors
 
-You may see one or more libgtk-related errors if you do not have everything set up for hardware virtualisation yet. If you have not yet done so, check out the [initial setup](https://github.com/sickcodes/Docker-OSX#initial-setup) section and the [routine checks](https://github.com/sickcodes/Docker-OSX#routine-checks) section as you may have missed a setup step or may not have all the needed Docker dependencies ready to go.
+You may see one or more libgtk-related errors if you do not have everything set up for hardware virtualisation yet. If you have not yet done so, check out the [initial setup](#initial-setup) section and the [routine checks](#routine-checks) section as you may have missed a setup step or may not have all the needed Docker dependencies ready to go.
 
 See also: [here](https://github.com/sickcodes/Docker-OSX/issues/174).
 
@@ -699,7 +702,7 @@ docker run -it \
     sickcodes/docker-osx:auto
 ```
 
-#### This example generates a specific set of serial numbers at runtime, with your existing image, at 1000x1000 display resolution.
+#### This example generates a specific set of serial numbers at runtime, with your existing image, at 1000x1000 display resolution
 
 ```bash
 # run an existing image in current directory, with a screen, with SSH, with nopicker.
@@ -1017,7 +1020,9 @@ The Quick Start command should work out of the box, provided that you keep the f
     -e "DISPLAY=${DISPLAY:-:0.0}" \
 ```
 
-#### Download the image manually and use it in Docker [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/naked?label=sickcodes%2Fdocker-osx%3Anaked](https://img.shields.io/docker/image-size/sickcodes/docker-osx/naked?label=sickcodes%2Fdocker-osx%3Anaked)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
+#### Download the image manually and use it in Docker 
+
+[![https://img.shields.io/docker/image-size/sickcodes/docker-osx/naked?label=sickcodes%2Fdocker-osx%3Anaked](https://img.shields.io/docker/image-size/sickcodes/docker-osx/naked?label=sickcodes%2Fdocker-osx%3Anaked)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
 
 
 This is a particularly good way for downloading the container, in case Docker's CDN (or your connection) happens to be slow.
@@ -1034,7 +1039,9 @@ docker run -it \
     sickcodes/docker-osx:naked
 ```
 
-#### Use a prebuilt image with arbitrary command line arguments [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/auto?label=sickcodes%2Fdocker-osx%3Aauto](https://img.shields.io/docker/image-size/sickcodes/docker-osx/auto?label=sickcodes%2Fdocker-osx%3Aauto)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
+#### Prebuilt image with arbitrary command line arguments 
+
+[![https://img.shields.io/docker/image-size/sickcodes/docker-osx/auto?label=sickcodes%2Fdocker-osx%3Aauto](https://img.shields.io/docker/image-size/sickcodes/docker-osx/auto?label=sickcodes%2Fdocker-osx%3Aauto)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
 
 ```bash
 docker pull sickcodes/docker-osx:auto
@@ -1064,7 +1071,9 @@ For a headless container, **remove** the following two lines from your `docker r
     # -e "DISPLAY=${DISPLAY:-:0.0}" \
 ```
 
-#### Building a headless container from a custom image [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/naked?label=sickcodes%2Fdocker-osx%3Anaked](https://img.shields.io/docker/image-size/sickcodes/docker-osx/naked?label=sickcodes%2Fdocker-osx%3Anaked)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
+#### Building a headless container from a custom image 
+
+[![https://img.shields.io/docker/image-size/sickcodes/docker-osx/naked?label=sickcodes%2Fdocker-osx%3Anaked](https://img.shields.io/docker/image-size/sickcodes/docker-osx/naked?label=sickcodes%2Fdocker-osx%3Anaked)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
 
 This is particularly helpful for CI/CD pipelines.
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,10 @@ Big thank you to our contributors who have worked out almost every conceivable i
 
 [https://github.com/sickcodes/Docker-OSX/blob/master/CREDITS.md](https://github.com/sickcodes/Docker-OSX/blob/master/CREDITS.md)
 
+### The big-sur image starts slowly after installation. Is this expected?
+
+Automatic updates are still on in the container's settings. You may wish to turn them off. [We have future plans for development around this.](https://github.com/sickcodes/Docker-OSX/issues/227)
+
 ### What is `${DISPLAY:-:0.0}`?
 
 `$DISPLAY` is the shell variable that refers to your X11 display server.
@@ -279,13 +283,22 @@ The directory that we are letting the Docker container use is a X server display
 
 If we let the Docker container use the same display socket as our own environment, then any applications you run inside the Docker container will show up on your screen too! [https://www.x.org/archive/X11R6.8.0/doc/RELNOTES5.html](https://www.x.org/archive/X11R6.8.0/doc/RELNOTES5.html)
 
-### I have used Docker-OSX before and would like to reuse the same container (persistent disk)
+### ALSA errors on startup or container creation
 
-1. You can now pull the `.img` file out of the container, which is stored in `/var/lib/docker`, and supply it as a runtime argument to the `:naked` Docker image. See above.
+You may when initialising or booting into a container see errors from the `(qemu)` console of the following form: 
+`ALSA lib blahblahblah: (function name) returned error: no such file or directory`. These are more or less expected. As long as you are able to boot into the container and everything is working, no reason to worry about these.
 
-2. This is for when you want to run the SAME container again later.
+See also: [here](https://github.com/sickcodes/Docker-OSX/issues/174).
 
-If you don't run this you will have a new image every time.
+### Start the same container later (persistent disk)
+
+Created a container with `docker run` and want to reuse the underlying image again later? 
+
+See [container creation examples](https://github.com/sickcodes/Docker-OSX#container-creation-examples) for how to get to the point where this is applicable.
+
+This is for when you want to run the SAME container again later. You may need to use `docker commit` to save your container before you can reuse it. Check if your container is persisted with `docker ps --all`.
+
+If you don't run this you will have a new image every time. 
 
 ```bash
 # look at your recent containers and copy the CONTAINER ID
@@ -301,13 +314,9 @@ docker start -ai abc123xyz567
 
 ```
 
-### I have used Docker-OSX before and would like to extract the Mac OSX image from my container
+You can also pull the `.img` file out of the container, which is stored in `/var/lib/docker`, and supply it as a runtime argument to the `:naked` Docker image. 
 
-Use `docker commit`, copy the ID, and then run `docker start -ai <Replace this with your ID>`.
-
-**Alternatively:**
-
-[Extract the .img file](https://github.com/sickcodes/Docker-OSX#backup-the-disk-wheres-my-disk), and then use that [.img file with :naked](https://github.com/sickcodes/Docker-OSX#quick-start-own-image-naked-container-image)
+See also: [here](https://github.com/sickcodes/Docker-OSX/issues/197).
 
 ### I have used Docker-OSX before and want to restart a container that starts automatically
 
@@ -324,6 +333,8 @@ docker start -ai -i <Replace this with your ID>
 ### LibGTK errors
 
 You may see one or more libgtk-related errors if you do not have everything set up for hardware virtualisation yet. If you have not yet done so, check out the [initial setup](https://github.com/sickcodes/Docker-OSX#initial-setup) section and the [routine checks](https://github.com/sickcodes/Docker-OSX#routine-checks) section as you may have missed a setup step or may not have all the needed Docker dependencies ready to go.
+
+See also: [here](https://github.com/sickcodes/Docker-OSX/issues/174).
 
 #### Permissions denied error
 
@@ -349,7 +360,7 @@ xhost +
 ### RAM over-allocation
 You cannot allocate more RAM than your machine has. The default is 3 Gigabytes: `-e RAM=3`.
 
-If you are trying to allocate more RAM to the container than you currently have available, you may see an error like the following: `cannot set up guest memory 'pc.ram': Cannot allocate memory`.
+If you are trying to allocate more RAM to the container than you currently have available, you may see an error like the following: `cannot set up guest memory 'pc.ram': Cannot allocate memory`. See also: [here](https://github.com/sickcodes/Docker-OSX/issues/188), [here](https://github.com/sickcodes/Docker-OSX/pull/189).
 
 For example (below) the `buff/cache` already contains 20 Gigabytes of allocated RAM:
 
@@ -441,6 +452,12 @@ Additionally, you can string multiple statements together, for example:
     -p 10023:10023 \
     -p 10043:10043 \
 ```
+
+### Bridged networking
+
+You might not need to do anything with the default setup to enable internet connectivity from inside the container. Additionally, `curl` may work even if `ping` doesn't.
+
+See discussion [here](https://github.com/sickcodes/Docker-OSX/issues/177) and [here](https://github.com/sickcodes/Docker-OSX/issues/72) and [here](https://github.com/sickcodes/Docker-OSX/issues/88).
 
 ### Enable IPv4 forwarding for bridged network connections for remote installations
 
@@ -764,7 +781,14 @@ Or tell the container to use specific ones using `-e GENERATE_SPECIFIC=true`
     -e MAC_ADDRESS="A8:5C:2C:9A:46:2F" \
 ```
 
-### Change Resolution Docker-OSX - change resolution OpenCore OSX-KVM
+### I'd like to run Docker-OSX with WSL2 (Windows, Ubuntu)
+
+Ensure KVM is enabled and `x11-apps` is installed. 
+
+See more in-depth discussion [here](https://github.com/sickcodes/Docker-OSX/issues/17) and [here](https://github.com/sickcodes/Docker-OSX/issues/60).
+
+
+### Changing display resolution
 
 The display resolution is controlled by this line:
 
@@ -887,6 +911,8 @@ docker run -it \
     -e EXTRA='-device ide-hd,bus=sata.5,drive=DISK-TWO -drive id=DISK-TWO,if=none,file=/disktwo,format=qcow2' \
     sickcodes/docker-osx:naked
 ```
+
+See also: [here](https://github.com/sickcodes/Docker-OSX/issues/222).
 
 ### USB Passthrough
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ echo 1 | sudo tee /sys/module/kvm/parameters/ignore_msrs
 sudo modprobe kvm
 ```
 
-## Additional boot instructions for when you are creating your container using whatever [method](https://github.com/sickcodes/Docker-OSX#container-creation-examples) you choose
+## Additional boot instructions for when you are [creating your container](https://github.com/sickcodes/Docker-OSX#container-creation-examples)
 
 - Boot the macOS Base System
 
@@ -545,7 +545,7 @@ Then run it with these arguments.
     mycustomimage
 ```
 
-## Setting the appropriate mirrors when building Docker-OSX locally
+### What mirrors are appropriate to use to build Docker-OSX locally?
 
 If you are building Docker-OSX locally, you'll probably want to use Arch Linux's mirrors.
 
@@ -856,7 +856,7 @@ Here's a few other resolutions! If you resolution is invalid, it will default to
     -e HEIGHT=1600 \
 ```
 
-### Mounting physical disks in Mac OS X
+### Mounting physical disks in Mac OSX
 
 Pass the disk into the container as a volume and then pass the disk again into QEMU command line extras with.
 
@@ -871,7 +871,7 @@ DISK_TWO="${PWD}/mount_me.img"
 -e EXTRA='-device ide-hd,bus=sata.5,drive=DISK-TWO -drive id=DISK-TWO,if=none,file=/disktwo,format=qcow2' \
 ```
 
-### Example
+#### Physical disk mounting example
 
 ```bash
 OSX_IMAGE="${PWD}/mac_hdd_ng_xcode_bigsur.img"
@@ -890,9 +890,9 @@ docker run -it \
 
 ### USB Passthrough
 
-The simplest way to do this is the following:
+Firstly, QEMU must be started as root. 
 
-First of all, in order to do this, QEMU must be started as root. It is also potentially possible to do this by changing the permissions of the device in the container.
+It is also potentially possible to accomplish USB passthrough by changing the permissions of the device in the container.
 See [here](https://www.linuxquestions.org/questions/slackware-14/qemu-usb-permissions-744557/#post3628691).
 
 For example, create a new Dockerfile with the following
@@ -906,7 +906,7 @@ COPY --chown=arch ./new_image.img /home/arch/OSX-KVM/mac_hdd_ng.img
 
 Where `new_image.img` is the qcow2 image you extracted. Then rebuild with `docker build .`
 
-Find out the bus and port numbers of your USB device which you want to pass through to the VM.
+Next we need to find out the bus and port numbers of the USB device we want to pass through to the VM:
 
 ```bash
 lsusb -t
@@ -1008,7 +1008,7 @@ docker run -it \
     sickcodes/docker-osx:naked
 ```
 
-#### Use a pre-built image + arbitrary command line arguments. [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/auto?label=sickcodes%2Fdocker-osx%3Aauto](https://img.shields.io/docker/image-size/sickcodes/docker-osx/auto?label=sickcodes%2Fdocker-osx%3Aauto)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
+#### Use a prebuilt image with arbitrary command line arguments [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/auto?label=sickcodes%2Fdocker-osx%3Aauto](https://img.shields.io/docker/image-size/sickcodes/docker-osx/auto?label=sickcodes%2Fdocker-osx%3Aauto)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
 
 ```bash
 docker pull sickcodes/docker-osx:auto

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Follow [@sickcodes](https://twitter.com/sickcodes)!
 
 ### Professional support
 
-For more sophisticated endeavours, we offer the following support services: 
+For more sophisticated endeavours, we offer the following support services:
 
 - Enterprise support, business support, or casual support.
 - Custom images, custom scripts, consulting (per hour available!)
@@ -324,13 +324,13 @@ docker start -ai -i <Replace this with your ID>
 
 This is my favourite container. You can supply an existing disk image as a Docker command line argument.
 
-- Pull images out using `sudo find /var/lib/docker -size +10G | grep mac_hdd_ng.img` 
+- Pull images out using `sudo find /var/lib/docker -size +10G | grep mac_hdd_ng.img`
 
 - Supply your own local image with the command argument `-v "${PWD}/mac_hdd_ng.img:/image"` and use `sickcodes/docker-osx:naked` when instructing Docker to create your container.
 
   - Naked image is for booting any existing .img file, e.g in the current working directory (`$PWD`)
   - By default, this image has a variable called `NOPICKER` which is `"true"`. This skips the disk selection menu. Use `-e NOPICKER=false` or any other string than the word `true` to enter the boot menu.
-    
+
     This lets you use other disks instead of skipping the boot menu, e.g. recovery disk or disk utility.
 
 ```bash
@@ -496,11 +496,15 @@ docker run \
 
 Big thank you to our contributors who have worked out almost every conceivable issue so far!
 
-### LibGTK - Permission denied
-
 [https://github.com/sickcodes/Docker-OSX/blob/master/CREDITS.md](https://github.com/sickcodes/Docker-OSX/blob/master/CREDITS.md)
 
-#### libgtk permissions denied error
+#### LibGTK
+
+You may see a LibGTK-related error if you do not have everything you need set up for hardware virtualisation yet. If you have not yet done so, check out the [KVM on the host](https://github.com/kaoudis/Docker-OSX#requirements-kvm-on-the-host) section.
+
+##### LibGTK: permissions denied error
+
+If you are fully set up with KVM, the issue may be with X11/Xorg:
 
 ```bash
 echo $DISPLAY
@@ -549,9 +553,9 @@ Swap:           11Gi          0B        11Gi
 
 Of course you cannot allocate more RAM that your have. The default is 3 Gigabytes: `-e RAM=3`.
 
-#### PulseAudio
+### PulseAudio
 
-### Use PulseAudio for sound 
+#### Use PulseAudio for sound
 
 Note: [AppleALC](https://github.com/acidanthera/AppleALC), [`alcid`](https://dortania.github.io/OpenCore-Post-Install/universal/audio.html) and [VoodooHDA-OC](https://github.com/chris1111/VoodooHDA-OC) do not have [codec support](https://osy.gitbook.io/hac-mini-guide/details/hda-fix#hda-codec). However, [IORegistryExplorer](https://github.com/vulgo/IORegistryExplorer) does show the controller component working.
 
@@ -576,7 +580,7 @@ docker run \
     sickcodes/docker-osx pactl list
 ```
 
-#### Nested Hardware Virtualization
+### Nested Hardware Virtualization
 
 Check if your PC has hardware virtualization enabled:
 
@@ -586,7 +590,7 @@ sudo tee /sys/module/kvm/parameters/ignore_msrs <<< 1
 egrep -c '(svm|vmx)' /proc/cpuinfo
 ```
 
-### Routine checks
+## Routine checks
 
 #### Confirm that your CPU supports virtualization
 
@@ -982,7 +986,7 @@ generate-specific-bootdisk.sh \
     --output-bootdisk OpenCore-nopicker.qcow2
 ```
 
-# Change Resolution Docker-OSX - change resolution OpenCore OSX-KVM 
+# Change Resolution Docker-OSX - change resolution OpenCore OSX-KVM
 
 The display resolution is controlled by this line:
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ docker run -it \
 
 ## Technical details
 
-There currently 4 images, each with different use-cases (explained below):
+There currently four images, each with different use cases (explained [below](https://github.com/sickcodes/Docker-OSX#container-images)):
 
 [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/latest?label=sickcodes%2Fdocker-osx%3Alatest](https://img.shields.io/docker/image-size/sickcodes/docker-osx/latest?label=sickcodes%2Fdocker-osx%3Alatest)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
 
@@ -103,7 +103,7 @@ Feel free to open an [issue](https://github.com/sickcodes/Docker-OSX/issues/new/
 
 #### Resolved issues
 
-Before you open an issue, however, please check the [closed issues](https://github.com/sickcodes/Docker-OSX/issues?q=is%3Aissue+is%3Aclosed) and confirm that you're using the latest version of this repository — your issues may have already been resolved!
+Before you open an issue, however, please check the [closed issues](https://github.com/sickcodes/Docker-OSX/issues?q=is%3Aissue+is%3Aclosed) and confirm that you're using the latest version of this repository — your issues may have already been resolved! You might also see your answer in our questions and answers section [below](https://github.com/sickcodes/Docker-OSX#more-questions-and-answers).
 
 ### Feature requests and updates
 
@@ -133,11 +133,13 @@ If you are serious about Apple Security, and possibly finding 6-figure bug bount
 
 Product names, logos, brands and other trademarks referred to within this project are the property of their respective trademark holders. These trademark holders are not affiliated with our repository in any capacity. They do not sponsor or endorse this project in any way.
 
-## Instructions
+# Instructions
 
-### Container images
+## Container images
 
-There are three different Docker images available, which are suitable for different purposes:  **latest**, **auto** and **naked**.
+### Already set up or just looking to make a container quickly? Check out our [container creation examples](https://github.com/sickcodes/Docker-OSX#container-creation-examples) section.
+
+There are several different Docker images available, which are suitable for different purposes.
 
 - `sickcodes/docker-osx:latest` - [I just want to try it out.](https://github.com/sickcodes/Docker-OSX#quick-start-large-pre-made-image)
 - `sickcodes/docker-osx:latest` - [I want to use Docker-OSX to develop/secure apps in Xcode (sign into Xcode, Transporter)](https://github.com/sickcodes/Docker-OSX#basic-quick-start-docker-osx)
@@ -146,278 +148,13 @@ There are three different Docker images available, which are suitable for differ
 Create your personal image using `:latest`. Then, extract the image. Afterwards, you will be able to duplicate that image and import it to the `:naked` container, in order to revert the container to a previous state repeatedly.
 
 - `sickcodes/docker-osx:auto` - [I'm only interested in using the command line. (Useful for compiling software or using Homebrew headlessly).](https://github.com/sickcodes/Docker-OSX#pre-built-image-arbitrary-command-line-arguments)
-- `sickcodes/docker-osx:naked` - [I need iMessage/iCloud for security research.](https://github.com/sickcodes/Docker-OSX#serial-numbers)
+- `sickcodes/docker-osx:naked` - [I need iMessage/iCloud for security research.](https://github.com/sickcodes/Docker-OSX#generating-serial-numbers)
+- `sickcodes/docker-osx:big-sur` - [I want to run Big Sur.](https://github.com/sickcodes/Docker-OSX#technical-details)
 
-## I need video output.
+## Initial setup
+Before you do anything else, you will need to turn on hardware virtualization in your BIOS. Precisely how will depend on your particular machine (and BIOS), but it should be straightforward.
 
-The Quick Start command should work out of the box, provided that you keep the following lines. Works in `auto` & `naked` machines:
-
-```
-    -v /tmp/.X11-unix:/tmp/.X11-unix \
-    -e "DISPLAY=${DISPLAY:-:0.0}" \
-```
-
-## I need to use Docker-OSX headlessly.
-
-In that case, **remove** the two lines in your command:
-
-```
-    # -v /tmp/.X11-unix:/tmp/.X11-unix \
-    # -e "DISPLAY=${DISPLAY:-:0.0}" \
-```
-
-## I need VNC on localhost (Local use only!)
-
-### VNC Insecure
-
-**Must change -it to -i to be able to interact with the QEMU console**
-
-**To exit a container using -i you must `docker kill <containerid>`. For example, to kill everything, `docker ps | xargs docker kill`.**
-
-Native QEMU VNC example
-
-```bash
-docker run -i \
-    --device /dev/kvm \
-    -p 50922:10022 \
-    -p 5999:5999 \
-    -v /tmp/.X11-unix:/tmp/.X11-unix \
-    -e "DISPLAY=${DISPLAY:-:0.0}" \
-    -e EXTRA="-display none -vnc 0.0.0.0:99,password" \
-    sickcodes/docker-osx:big-sur
-
-# type `change vnc password` into the docker terminal and set a password
-# connect to localhost:5999 using VNC
-```
-
-**NOT TLS/HTTPS Encrypted at all!**
-
-Or `ssh -N root@1.1.1.1 -L  5999:127.0.0.1:5999`, where `1.1.1.1` is your remote server IP.
-
-(Note: if you close port 5999 and use the SSH tunnel, this becomes secure.)
-
-## I need VNC to a Remote Host (Secure)
-
-Now you can direct connect VNC to any image!
-
-Add the following line:
-
-`-e EXTRA="-display none -vnc 0.0.0.0:99,password"`
-
-In the Docker terminal, press `enter` until you see `(qemu)`.
-
-Type `change vnc password`
-
-You also need the container IP: `docker inspect <containerid> | jq -r '.[0].NetworkSettings.IPAddress'`
-
-Or `ip n` will usually show the container IP first.
-
-Now VNC connect using the Docker container IP, for example `172.17.0.2:5999`
-
-Remote VNC over SSH: `ssh -N root@1.1.1.1 -L  5999:172.17.0.2:5999`, where `1.1.1.1` is your remote server IP and `172.17.0.2` is your LAN container IP.
-
-#### I have used Docker-OSX before and wish to extract my Mac OS X image.
-
-Use `docker commit`, copy the ID, and then run `docker start -ai <Replace this with your ID>`.
-
-**Alternatively:**
-
-[Extract the .img file](https://github.com/sickcodes/Docker-OSX#backup-the-disk-wheres-my-disk), and then use that [.img file with :naked](https://github.com/sickcodes/Docker-OSX#quick-start-own-image-naked-container-image)
-
-#### Further examples
-
-Apart from the previous examples, there's a myriad of other potential use cases that can work perfectly with Docker-OSX, which you'll see below!
-
-### Run Catalina Pre-Installed [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/auto?label=sickcodes%2Fdocker-osx%3Aauto](https://img.shields.io/docker/image-size/sickcodes/docker-osx/auto?label=sickcodes%2Fdocker-osx%3Aauto)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
-
-```bash
-docker pull sickcodes/docker-osx:auto
-
-# boot directly into a real OS X shell with a visual display [NOT HEADLESS]
-docker run -it \
-    --device /dev/kvm \
-    -p 50922:10022 \
-    -v /tmp/.X11-unix:/tmp/.X11-unix \
-    -e "DISPLAY=${DISPLAY:-:0.0}" \
-    sickcodes/docker-osx:auto
-
-# username is user
-# passsword is alpine
-```
-
-```bash
-docker pull sickcodes/docker-osx:auto
-
-# boot directly into a real OS X shell with no display (Xvfb) [HEADLESS]
-docker run -it \
-    --device /dev/kvm \
-    -p 50922:10022 \
-    sickcodes/docker-osx:auto
-
-# username is user
-# passsword is alpine
-# Wait 2-3 minutes until you drop into the shell.
-```
-
-
-### Download the image manually and use it in Docker [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/naked?label=sickcodes%2Fdocker-osx%3Anaked](https://img.shields.io/docker/image-size/sickcodes/docker-osx/naked?label=sickcodes%2Fdocker-osx%3Anaked)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
-
-
-This is a particularly good way for downloading the container, in case Docker's CDN (or your connection) happens to be slow.
-
-```bash
-wget https://images2.sick.codes/mac_hdd_ng_auto.img
-
-docker run -it \
-    --device /dev/kvm \
-    -p 50922:10022 \
-    -v "${PWD}/mac_hdd_ng_auto.img:/image" \
-    -v /tmp/.X11-unix:/tmp/.X11-unix \
-    -e "DISPLAY=${DISPLAY:-:0.0}" \
-    sickcodes/docker-osx:naked
-```
-
-### Use a pre-built image + arbitrary command line arguments. [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/auto?label=sickcodes%2Fdocker-osx%3Aauto](https://img.shields.io/docker/image-size/sickcodes/docker-osx/auto?label=sickcodes%2Fdocker-osx%3Aauto)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
-
-```bash
-docker pull sickcodes/docker-osx:auto
-
-# boot to OS X shell + display + specify commands to run inside OS X!
-docker run -it \
-    --device /dev/kvm \
-    -p 50922:10022 \
-    -v /tmp/.X11-unix:/tmp/.X11-unix \
-    -e "DISPLAY=${DISPLAY:-:0.0}" \
-    -e "OSX_COMMANDS=/bin/bash -c \"pwd && uname -a\"" \
-    sickcodes/docker-osx:auto
-
-# Boots in a minute or two!
-```
-
-### Run Mac OS X headlessly with a custom image [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/naked?label=sickcodes%2Fdocker-osx%3Anaked](https://img.shields.io/docker/image-size/sickcodes/docker-osx/naked?label=sickcodes%2Fdocker-osx%3Anaked)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
-
-
-This is particularly helpful for CI/CD pipelines.
-
-```bash
-# run your own image headless + SSH
-docker run -it \
-    --device /dev/kvm \
-    -p 50922:10022 \
-    -v "${PWD}/mac_hdd_ng.img:/image" \
-    sickcodes/docker-osx:naked
-```
-
-### Restart a container that starts automatically
-
-Containers that use `sickcodes/docker-osx:auto` can be stopped while being started.
-
-```bash
-# find last container
-docker ps -a
-
-# docker start old container with -i for interactive, -a for attach STDIN/STDOUT
-docker start -ai -i <Replace this with your ID>
-```
-
-### Quick Start your own image (naked container image)
-
-This is my favourite container. You can supply an existing disk image as a Docker command line argument.
-
-- Pull images out using `sudo find /var/lib/docker -size +10G | grep mac_hdd_ng.img`
-
-- Supply your own local image with the command argument `-v "${PWD}/mac_hdd_ng.img:/image"` and use `sickcodes/docker-osx:naked` when instructing Docker to create your container.
-
-  - Naked image is for booting any existing .img file, e.g in the current working directory (`$PWD`)
-  - By default, this image has a variable called `NOPICKER` which is `"true"`. This skips the disk selection menu. Use `-e NOPICKER=false` or any other string than the word `true` to enter the boot menu.
-
-    This lets you use other disks instead of skipping the boot menu, e.g. recovery disk or disk utility.
-
-```bash
-docker pull sickcodes/docker-osx:naked
-
-# run your own image + SSH
-# change mac_hdd_ng.img
-docker run -it \
-    --device /dev/kvm \
-    -p 50922:10022 \
-    -v "${PWD}/mac_hdd_ng.img:/image" \
-    -v /tmp/.X11-unix:/tmp/.X11-unix \
-    -e "DISPLAY=${DISPLAY:-:0.0}" \
-    sickcodes/docker-osx:naked
-
-# run local copy of the auto image + SSH + Boot menu
-docker run -it \
-    --device /dev/kvm \
-    -p 50922:10022 \
-    -v "${PWD}/mac_hdd_ng_auto.img:/image" \
-    -v /tmp/.X11-unix:/tmp/.X11-unix \
-    -e "DISPLAY=${DISPLAY:-:0.0}" \
-    -e "NOPICKER=false" \
-    sickcodes/docker-osx:naked
-```
-
-### Run the original version of Docker-OSX
-
-```bash
-
-docker pull sickcodes/docker-osx:latest
-
-docker run -it \
-    --device /dev/kvm \
-    --device /dev/snd \
-    -v /tmp/.X11-unix:/tmp/.X11-unix \
-    -e "DISPLAY=${DISPLAY:-:0.0}" \
-    sickcodes/docker-osx:latest
-
-# press CTRL + G if your mouse gets stuck
-# scroll down to troubleshooting if you have problems
-# need more RAM and SSH on localhost -p 50922?
-```
-
-# Run but enable SSH in OS X (Original Version)!
-
-```bash
-docker run -it \
-    --device /dev/kvm \
-    --device /dev/snd \
-    -p 50922:10022 \
-    -v /tmp/.X11-unix:/tmp/.X11-unix \
-    -e "DISPLAY=${DISPLAY:-:0.0}" \
-    sickcodes/docker-osx:latest
-
-# turn on SSH after you've installed OS X in the "Sharing" settings.
-ssh user@localhost -p 50922
-```
-
-### Autoboot into OS X after you've installed everything
-
-You can use `-e NOPICKER=true`.
-
-Old machines:
-
-```bash
-# find you containerID
-docker ps
-
-# move the no picker script on top of the Launch script
-# NEW CONTAINERS
-docker exec containerID mv ./Launch-nopicker.sh ./Launch.sh
-
-# VNC-VERSION-CONTAINER
-docker exec containerID mv ./Launch-nopicker.sh ./Launch_custom.sh
-
-# LEGACY CONTAINERS
-docker exec containerID bash -c "grep -v InstallMedia ./Launch.sh > ./Launch-nopicker.sh
-chmod +x ./Launch-nopicker.sh
-sed -i -e s/OpenCore\.qcow2/OpenCore\-nopicker\.qcow2/ ./Launch-nopicker.sh
-"
-```
-
-# Requirements: KVM on the host
-Need to turn on hardware virtualization in your BIOS, very easy to do.
-
-Then have QEMU on the host if you haven't already
+Then, you'll need QEMU and some other dependencies on your host:
 
 ```bash
 # ARCH
@@ -428,8 +165,11 @@ sudo apt install qemu qemu-kvm libvirt-clients libvirt-daemon-system bridge-util
 
 # CENTOS RHEL FEDORA
 sudo yum install libvirt qemu-kvm
+```
 
-# then run
+Then, enable libvirt and load the KVM kernel module:
+
+```bash
 sudo systemctl enable --now libvirtd
 sudo systemctl enable --now virtlogd
 
@@ -438,7 +178,108 @@ echo 1 | sudo tee /sys/module/kvm/parameters/ignore_msrs
 sudo modprobe kvm
 ```
 
-# Start the same container later (persistent disk)
+## Additional boot instructions for when you are creating your container using whatever [method](https://github.com/sickcodes/Docker-OSX#container-creation-examples) you choose
+
+- Boot the macOS Base System
+
+- Click `Disk Utility`
+
+- Erase the BIGGEST disk (around 200gb default), DO NOT MODIFY THE SMALLER DISKS.
+-- if you can't click `erase`, you may need to reduce the disk size by 1kb
+
+- (optional) Create a partition using the unused space to house the OS and your files if you want to limit the capacity. (For Xcode 12 partition at least 60gb.)
+
+- Click `Reinstall macOS`
+
+## Troubleshooting
+
+### Routine checks
+
+This is a great place to start if you are having trouble getting going, especially if you're not that familiar with Docker just yet.
+
+Just looking to make a container quickly? Check out our [container creation examples](https://github.com/sickcodes/Docker-OSX#container-creation-examples) section.
+
+More specific/advanced troubleshooting questions and answers may be found in [More Questions and Answers](https://github.com/sickcodes/Docker-OSX#more-questions-and-answers). You should also check out the [closed issues](https://github.com/sickcodes/Docker-OSX/issues?q=is%3Aissue+is%3Aclosed). Someone else might have gotten a question like yours answered already even if you can't find it in this document!
+
+#### Confirm that your CPU supports virtualization
+
+See [initial setup](https://github.com/sickcodes/Docker-OSX#initial-setup).
+
+#### Confirm your user is part of the the Docker group, KVM group, libvirt group
+
+If you use `sudo dockerd` or dockerd is controlled by systemd/systemctl, then you must be in the Docker group.
+If you are not in the Docker group:
+
+```bash
+sudo usermod -aG docker "${USER}"
+```
+and also add yourself to the kvm and libvirt groups if needed:
+
+```bash
+sudo usermod -aG libvirt "${USER}"
+sudo usermod -aG kvm "${USER}"
+```
+
+See also: [initial setup](https://github.com/sickcodes/Docker-OSX#initial-setup).
+
+#### Is the docker daemon enabled?
+
+```bash
+# enable it in systemd (it will persist across reboots this way)
+sudo systemctl enable --now docker
+
+# or just start it as your user with systemd instead of enabling it
+systemctl start docker
+
+# or run ad hoc
+sudo dockerd
+
+# or daemonize it
+sudo nohup dockerd &
+```
+
+## More Questions and Answers
+
+Big thank you to our contributors who have worked out almost every conceivable issue so far!
+
+[https://github.com/sickcodes/Docker-OSX/blob/master/CREDITS.md](https://github.com/sickcodes/Docker-OSX/blob/master/CREDITS.md)
+
+### What is `${DISPLAY:-:0.0}`?
+
+`$DISPLAY` is the shell variable that refers to your X11 display server.
+
+`${DISPLAY}` is the same, but allows you to join variables like this:
+
+- e.g. `${DISPLAY}_${DISPLAY}` would print `:0.0_:0.0`
+- e.g. `$DISPLAY_$DISPLAY`     would print `:0.0`
+
+...because `$DISPLAY_` is not `$DISPLAY`
+
+`${variable:-fallback}` allows you to set a "fallback" variable to be substituted if `$variable` is not set.
+
+You can also use `${variable:=fallback}` to set that variable (in your current terminal).
+
+In Docker-OSX, we assume, `:0.0` is your default `$DISPLAY` variable.
+
+You can see what yours is
+
+```bash
+echo $DISPLAY
+```
+
+That way, `${DISPLAY:-:0.0}` will use whatever variable your X11 server has set for you, else `:0.0`
+
+### What is `-v /tmp/.X11-unix:/tmp/.X11-unix`?
+
+`-v` is a Docker command-line option that lets you pass a volume to the container.
+
+The directory that we are letting the Docker container use is a X server display socket.
+
+`/tmp/.X11-unix`
+
+If we let the Docker container use the same display socket as our own environment, then any applications you run inside the Docker container will show up on your screen too! [https://www.x.org/archive/X11R6.8.0/doc/RELNOTES5.html](https://www.x.org/archive/X11R6.8.0/doc/RELNOTES5.html)
+
+### I have used Docker-OSX before and would like to reuse the same container (persistent disk)
 
 1. You can now pull the `.img` file out of the container, which is stored in `/var/lib/docker`, and supply it as a runtime argument to the `:naked` Docker image. See above.
 
@@ -460,51 +301,33 @@ docker start -ai abc123xyz567
 
 ```
 
-# Additional Boot Instructions
+### I have used Docker-OSX before and would like to extract the Mac OSX image from my container
 
-- Boot the macOS Base System
+Use `docker commit`, copy the ID, and then run `docker start -ai <Replace this with your ID>`.
 
-- Click `Disk Utility`
+**Alternatively:**
 
-- Erase the BIGGEST disk (around 200gb default), DO NOT MODIFY THE SMALLER DISKS.
--- if you can't click `erase`, you may need to reduce the disk size by 1kb
+[Extract the .img file](https://github.com/sickcodes/Docker-OSX#backup-the-disk-wheres-my-disk), and then use that [.img file with :naked](https://github.com/sickcodes/Docker-OSX#quick-start-own-image-naked-container-image)
 
-- (optional) Create a partition using the unused space to house the OS and your files if you want to limit the capacity. (For Xcode 12 partition at least 60gb.)
+### I have used Docker-OSX before and want to restart a container that starts automatically
 
-- Click `Reinstall macOS`
+Containers that use `sickcodes/docker-osx:auto` can be stopped while being started.
 
-
-## Creating images:
 ```bash
-# You can create an image of an already configured and setup container.
-# This allows you to effectively duplicate a system.
-# To do this, run the following commands
+# find last container
+docker ps -a
 
-# make note of your container id
-docker ps --all
-docker commit containerid newImageName
-
-# To run this image do the following
-docker run \
-    --device /dev/kvm \
-    --device /dev/snd \
-    -v /tmp/.X11-unix:/tmp/.X11-unix \
-    newImageName
+# docker start old container with -i for interactive, -a for attach STDIN/STDOUT
+docker start -ai -i <Replace this with your ID>
 ```
 
-## Troubleshooting
+### LibGTK errors
 
-Big thank you to our contributors who have worked out almost every conceivable issue so far!
+You may see one or more libgtk-related errors if you do not have everything set up for hardware virtualisation yet. If you have not yet done so, check out the [initial setup](https://github.com/sickcodes/Docker-OSX#initial-setup) section and the [routine checks](https://github.com/sickcodes/Docker-OSX#routine-checks) section as you may have missed a setup step or may not have all the needed Docker dependencies ready to go.
 
-[https://github.com/sickcodes/Docker-OSX/blob/master/CREDITS.md](https://github.com/sickcodes/Docker-OSX/blob/master/CREDITS.md)
+#### Permissions denied error
 
-#### LibGTK
-
-You may see a LibGTK-related error if you do not have everything you need set up for hardware virtualisation yet. If you have not yet done so, check out the [KVM on the host](https://github.com/kaoudis/Docker-OSX#requirements-kvm-on-the-host) section.
-
-##### LibGTK: permissions denied error
-
-If you are fully set up with KVM, the issue may be with X11/Xorg:
+If you have not yet set up xhost, try the following:
 
 ```bash
 echo $DISPLAY
@@ -522,10 +345,13 @@ sudo yum install xorg-x11-server-utils
 xhost +
 
 ```
-#### RAM over-allocation Error
-Cause by trying to allocate more ram to the container than you currently have available for allocation: `cannot set up guest memory 'pc.ram': Cannot allocate memory`.
 
-For example:
+### RAM over-allocation
+You cannot allocate more RAM than your machine has. The default is 3 Gigabytes: `-e RAM=3`.
+
+If you are trying to allocate more RAM to the container than you currently have available, you may see an error like the following: `cannot set up guest memory 'pc.ram': Cannot allocate memory`.
+
+For example (below) the `buff/cache` already contains 20 Gigabytes of allocated RAM:
 
 ```console
 [user@hostname ~]$ free -mh
@@ -534,15 +360,13 @@ Mem:            30Gi       3.5Gi       7.0Gi       728Mi        20Gi        26Gi
 Swap:           11Gi          0B        11Gi
 ```
 
-In the example above, the `buff/cache` already contains 20 Gigabytes of allocated RAM.
-
 Clear the buffer and the cache:
 
 ```bash
 sudo tee /proc/sys/vm/drop_caches <<< 3
 ```
 
-Now check the ram again:
+Now check the RAM again:
 
 ```console
 [user@hostname ~]$ free -mh
@@ -550,8 +374,6 @@ Now check the ram again:
 Mem:            30Gi       3.3Gi        26Gi       697Mi       1.5Gi        26Gi
 Swap:           11Gi          0B        11Gi
 ```
-
-Of course you cannot allocate more RAM that your have. The default is 3 Gigabytes: `-e RAM=3`.
 
 ### PulseAudio
 
@@ -580,58 +402,15 @@ docker run \
     sickcodes/docker-osx pactl list
 ```
 
-### Nested Hardware Virtualization
+### Forward additional ports (nginx hosting example)
 
-Check if your PC has hardware virtualization enabled:
-
-```bash
-sudo tee /sys/module/kvm/parameters/ignore_msrs <<< 1
-
-egrep -c '(svm|vmx)' /proc/cpuinfo
-```
-
-## Routine checks
-
-#### Confirm that your CPU supports virtualization
-
-#### Add yourself to the Docker group, KVM group, libvirt group.
-
-If you use `sudo dockerd` or dockerd is controlled by systemd/systemctl, then you must be in the Docker group:
-
-#### Try adding yourself to the docker group
-
-```bash
-sudo usermod -aG docker "${USER}"
-```
-and also to the kvm and libvirt groups:
-
-```bash
-sudo usermod -aG libvirt "${USER}"
-sudo usermod -aG kvm "${USER}"
-```
-
-#### Enable docker daemon
-
-```bash
-# enable it in systemd
-sudo systemctl enable --now docker
-
-# or run ad hoc
-sudo dockerd
-
-# or daemonize it
-sudo nohup dockerd &
-```
-
-#### Forward additional ports (nginx)
-
-It's possible to forward additional ports depending on your needs. In this example, we're going to use Mac OS X to host nginx in a way that looks like this:
+It's possible to forward additional ports depending on your needs. In this example, we'll use Mac OSX to host nginx:
 
 ```
 host:10023 <-> 10023:container:10023 <-> 80:guest
 ```
 
-On the host machine, you should run:
+On the host machine, run:
 
 ```bash
 docker run -it \
@@ -642,7 +421,7 @@ docker run -it \
     sickcodes/docker-osx:auto
 ```
 
-In a Terminal session running the container, you should run:
+In a Terminal session running the container, run:
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
@@ -653,9 +432,9 @@ sudo sed -i -e 's/8080/80/' /usr/local/etc/nginx/nginx.confcd
 sudo nginx
 ```
 
-**nginx should now be reachable on the port 10023.**
+**nginx should now be reachable on port 10023.**
 
-Additionally, you can string multiple statements, for example:
+Additionally, you can string multiple statements together, for example:
 
 ```bash
     -e ADDITIONAL_PORTS='hostfwd=tcp::10023-:80,hostfwd=tcp::10043-:443,'
@@ -663,9 +442,11 @@ Additionally, you can string multiple statements, for example:
     -p 10043:10043 \
 ```
 
-### Enable IPv4 forwarding for bridged network connections
+### Enable IPv4 forwarding for bridged network connections for remote installations
 
-This is not required for LOCAL installations and may [cause the host to leak your IP, even if you're using a VPN in the container](https://sick.codes/cve-2020-15590/).
+This is not required for LOCAL installations.
+
+Additionally note it may [cause the host to leak your IP, even if you're using a VPN in the container](https://sick.codes/cve-2020-15590/).
 
 However, if you're trying to connect to an instance of Docker-OSX remotely (e.g. an instance of Docker-OSX hosted in a datacenter), this may improve your performance:
 
@@ -688,7 +469,7 @@ nano /etc/sysctl.conf || vi /etc/sysctl.conf || vim /etc/sysctl.conf
 # now reboot
 ```
 
-### Fedora: No internet connectivity with a bridged network
+### Fedora: enable internet connectivity with a bridged network
 
 Fedora's default firewall settings may prevent Docker's network interface from reaching the internet. In order to reoslve this, you will need to whitelist the interface in your firewall:
 
@@ -696,6 +477,16 @@ Fedora's default firewall settings may prevent Docker's network interface from r
 # Set the docker0 bridge to the trusted zone
 sudo firewall-cmd --permanent --zone=trusted --add-interface=docker0
 sudo firewall-cmd --reload
+```
+
+### Nested Hardware Virtualization
+
+Check if your machine has hardware virtualization enabled:
+
+```bash
+sudo tee /sys/module/kvm/parameters/ignore_msrs <<< 1
+
+egrep -c '(svm|vmx)' /proc/cpuinfo
 ```
 
 ### Virtual network adapters
@@ -707,24 +498,6 @@ sudo firewall-cmd --reload
 #### Slow internet connectivity
 
 `-e NETWORKING=e1000-82545em`
-
-
-### I'd like to use SPICE instead of VNC
-
-Optionally, you can enable the SPICE protocol, which allows you to use `remote-viewer` to access it rather than VNC.
-
-Note: `-disable-ticketing` will allow unauthenticated access to the VM. See the [spice manual](https://www.spice-space.org/spice-user-manual.html) for help setting up authenticated access ("Ticketing").
-
-```bash
-  docker run \
-    --device /dev/kvm \
-    -p 50922:10022 \
-    -e "DISPLAY=${DISPLAY:-:0.0}" \
-    -e EXTRA="-monitor telnet::45454,server,nowait -nographic -serial null -spice disable-ticketing,port=3001" \
-    mycustomimage
-```
-
-Then simply do `remote-viewer spice://localhost:3001` and add `--spice-debug` for debugging.
 
 ### CI/CD Related Improvements
 
@@ -772,11 +545,11 @@ Then run it with these arguments.
     mycustomimage
 ```
 
-## Setting the appropriate mirrors when building locally
+## Setting the appropriate mirrors when building Docker-OSX locally
 
-If you are building Docker-OSX locally, you'd probably want to use Arch Linux's mirrors.
+If you are building Docker-OSX locally, you'll probably want to use Arch Linux's mirrors.
 
-Mirror locations can be found here (use 2 letter country codes): https://archlinux.org/mirrorlist/all/
+Mirror locations can be found here (uses two-letter country codes): https://archlinux.org/mirrorlist/all/
 
 ```bash
 docker build -t docker-osx:latest \
@@ -789,7 +562,7 @@ docker build -t docker-osx:latest \
 
 ### Custom QEMU Arguments (passthrough devices)
 
-Pass any devices/directories to the Docker container & the QEMU arguments using the handy `-e EXTRA=` runtime options.
+Pass any devices/directories to the Docker container & the QEMU arguments using the handy runtime argument provider option `-e EXTRA=`.
 
 ```bash
 # example customizations
@@ -813,18 +586,69 @@ docker run \
 
 ### Generating serial numbers
 
-For serial numbers, generate them in `./custom` OR make docker generate them at runtime (see below).
+Generate serial numbers in `./custom` OR make docker generate them at runtime (see below).
 
-At any time, verify your serial number before logging in iCloud, etc.
+At any time, verify your serial number before logging into iCloud, etc.
 
 ```bash
-# this is a quick way to check your serial number via cli inside OS X
+# this is a quick way to check your serial number via cli inside OSX
 ioreg -l | grep IOPlatformSerialNumber
 
 # or from the host
 sshpass -p 'alpine' ssh user@localhost -p 50922 'ioreg -l | grep IOPlatformSerialNumber'
 ```
-# This example generates a random set of serial numbers at runtime, headlessly
+
+#### Getting started with serial numbers
+
+```bash
+# ARCH
+pacman -S libguestfs
+
+# UBUNTU DEBIAN
+apt install libguestfs -y
+
+# RHEL FEDORA CENTOS
+yum install libguestfs -y
+```
+
+Inside the `./custom` folder you will find `4` scripts.
+
+- `config-nopicker-custom.plist`
+- `opencore-image-ng.sh`
+
+These two files are from OSX-KVM.
+
+You don't need to touch these two files.
+
+The config.plist has 5 values replaced with placeholders. [Click here to see those values for no reason.](https://github.com/sickcodes/Docker-OSX/blob/master/custom/config-nopicker-custom.plist#L705)
+
+- `generate-unique-machine-values.sh`
+This script will generate serial numbers, with Mac Addresses, plus output to CSV/TSV, plus make a `bootdisk image`.
+
+You can create hundreds, `./custom/generate-unique-machine-values.sh --help`
+
+```bash
+./custom/generate-unique-machine-values.sh \
+    --count 1 \
+    --tsv ./serial.tsv \
+    --bootdisks \
+    --output-bootdisk OpenCore.qcow2 \
+    --output-env source.env.sh
+```
+
+Or if you have some specific serial numbers...
+
+- `generate-specific-bootdisk.sh`
+```bash
+generate-specific-bootdisk.sh \
+    --model "${DEVICE_MODEL}" \
+    --serial "${SERIAL}" \
+    --board-serial "${BOARD_SERIAL}" \
+    --uuid "${UUID}" \
+    --mac-address "${MAC_ADDRESS}" \
+    --output-bootdisk OpenCore-nopicker.qcow2
+```
+#### This example generates a random set of serial numbers at runtime, headlessly
 
 ```bash
 # proof of concept only, generates random serial numbers, headlessly, and quits right after.
@@ -838,7 +662,7 @@ docker run --rm -it \
     sickcodes/docker-osx:auto
 ```
 
-# This example generates a specific set of serial numbers at runtime
+#### This example generates a specific set of serial numbers at runtime
 
 ```bash
 # run the same as above 17gb auto image, with SSH, with nopicker, and save the bootdisk for later.
@@ -940,53 +764,7 @@ Or tell the container to use specific ones using `-e GENERATE_SPECIFIC=true`
     -e MAC_ADDRESS="A8:5C:2C:9A:46:2F" \
 ```
 
-#### How to obtain serial numbers
-
-```bash
-apt install libguestfs -y
-pacman -S libguestfs
-yum install libguestfs -y
-```
-
-Inside the `./custom` folder you will find `4` scripts.
-
-- `config-nopicker-custom.plist`
-- `opencore-image-ng.sh`
-
-These two files are from OSX-KVM.
-
-You don't need to touch these two files.
-
-The config.plist has 5 values replaced with placeholders. [Click here to see those values for no reason.](https://github.com/sickcodes/Docker-OSX/blob/master/custom/config-nopicker-custom.plist#L705)
-
-- `generate-unique-machine-values.sh`
-This script will generate serial numbers, with Mac Addresses, plus output to CSV/TSV, plus make a `bootdisk image`.
-
-You can create hundreds, `./custom/generate-unique-machine-values.sh --help`
-
-```bash
-./custom/generate-unique-machine-values.sh \
-    --count 1 \
-    --tsv ./serial.tsv \
-    --bootdisks \
-    --output-bootdisk OpenCore.qcow2 \
-    --output-env source.env.sh
-```
-
-Or if you have some specific serial numbers...
-
-- `generate-specific-bootdisk.sh`
-```bash
-generate-specific-bootdisk.sh \
-    --model "${DEVICE_MODEL}" \
-    --serial "${SERIAL}" \
-    --board-serial "${BOARD_SERIAL}" \
-    --uuid "${UUID}" \
-    --mac-address "${MAC_ADDRESS}" \
-    --output-bootdisk OpenCore-nopicker.qcow2
-```
-
-# Change Resolution Docker-OSX - change resolution OpenCore OSX-KVM
+### Change Resolution Docker-OSX - change resolution OpenCore OSX-KVM
 
 The display resolution is controlled by this line:
 
@@ -1014,7 +792,7 @@ It will take around 30 seconds longer to boot because it needs to make a new boo
 -e MAC_ADDRESS="" \
 ```
 
-## Change Docker-OSX Resolution Examples
+#### Change Docker-OSX Resolution Examples
 
 ```bash
 # using an image in your current directory
@@ -1050,7 +828,6 @@ docker run -it \
     -e HEIGHT=600 \
     sickcodes/docker-osx:latest
 ```
-
 
 Here's a few other resolutions! If you resolution is invalid, it will default to 800x600.
 
@@ -1166,37 +943,281 @@ You should see the device show up when you do `system_profiler SPUSBDataType` in
 
 Important Note: this will cause the host system to lose access to the USB device while the VM is running!
 
-#### What is `${DISPLAY:-:0.0}`?
+## Container creation examples
 
-`$DISPLAY` is the shell variable that refers to your X11 display server.
+#### Quick Start your own image (naked container image)
 
-`${DISPLAY}` is the same, but allows you to join variables like this:
+This is my favourite container. You can supply an existing disk image as a Docker command line argument.
 
-- e.g. `${DISPLAY}_${DISPLAY}` would print `:0.0_:0.0`
-- e.g. `$DISPLAY_$DISPLAY`     would print `:0.0`
+- Pull images out using `sudo find /var/lib/docker -size +10G | grep mac_hdd_ng.img`
 
-...because `$DISPLAY_` is not `$DISPLAY`
+- Supply your own local image with the command argument `-v "${PWD}/mac_hdd_ng.img:/image"` and use `sickcodes/docker-osx:naked` when instructing Docker to create your container.
 
-`${variable:-fallback}` allows you to set a "fallback" variable to be substituted if `$variable` is not set.
+  - Naked image is for booting any existing .img file, e.g in the current working directory (`$PWD`)
+  - By default, this image has a variable called `NOPICKER` which is `"true"`. This skips the disk selection menu. Use `-e NOPICKER=false` or any other string than the word `true` to enter the boot menu.
 
-You can also use `${variable:=fallback}` to set that variable (in your current terminal).
-
-In Docker-OSX, we assume, `:0.0` is your default `$DISPLAY` variable.
-
-You can see what yours is
+    This lets you use other disks instead of skipping the boot menu, e.g. recovery disk or disk utility.
 
 ```bash
-echo $DISPLAY
+docker pull sickcodes/docker-osx:naked
+
+# run your own image + SSH
+# change mac_hdd_ng.img
+docker run -it \
+    --device /dev/kvm \
+    -p 50922:10022 \
+    -v "${PWD}/mac_hdd_ng.img:/image" \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -e "DISPLAY=${DISPLAY:-:0.0}" \
+    sickcodes/docker-osx:naked
+
+# run local copy of the auto image + SSH + Boot menu
+docker run -it \
+    --device /dev/kvm \
+    -p 50922:10022 \
+    -v "${PWD}/mac_hdd_ng_auto.img:/image" \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -e "DISPLAY=${DISPLAY:-:0.0}" \
+    -e "NOPICKER=false" \
+    sickcodes/docker-osx:naked
 ```
 
-That way, `${DISPLAY:-:0.0}` will use whatever variable your X11 server has set for you, else `:0.0`
+### Building an OSX container with video output
 
-#### What is `-v /tmp/.X11-unix:/tmp/.X11-unix`?
+The Quick Start command should work out of the box, provided that you keep the following lines. Works in `auto` & `naked` machines:
 
-`-v` is a Docker command-line option that lets you pass a volume to the container.
+```
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -e "DISPLAY=${DISPLAY:-:0.0}" \
+```
 
-The directory that we are letting the Docker container use is a X server display socket.
+#### Download the image manually and use it in Docker [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/naked?label=sickcodes%2Fdocker-osx%3Anaked](https://img.shields.io/docker/image-size/sickcodes/docker-osx/naked?label=sickcodes%2Fdocker-osx%3Anaked)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
 
-`/tmp/.X11-unix`
 
-If we let the Docker container use the same display socket as our own environment, then any applications you run inside the Docker container will show up on your screen too! [https://www.x.org/archive/X11R6.8.0/doc/RELNOTES5.html](https://www.x.org/archive/X11R6.8.0/doc/RELNOTES5.html)
+This is a particularly good way for downloading the container, in case Docker's CDN (or your connection) happens to be slow.
+
+```bash
+wget https://images2.sick.codes/mac_hdd_ng_auto.img
+
+docker run -it \
+    --device /dev/kvm \
+    -p 50922:10022 \
+    -v "${PWD}/mac_hdd_ng_auto.img:/image" \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -e "DISPLAY=${DISPLAY:-:0.0}" \
+    sickcodes/docker-osx:naked
+```
+
+#### Use a pre-built image + arbitrary command line arguments. [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/auto?label=sickcodes%2Fdocker-osx%3Aauto](https://img.shields.io/docker/image-size/sickcodes/docker-osx/auto?label=sickcodes%2Fdocker-osx%3Aauto)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
+
+```bash
+docker pull sickcodes/docker-osx:auto
+
+# boot to OS X shell + display + specify commands to run inside OS X!
+docker run -it \
+    --device /dev/kvm \
+    -p 50922:10022 \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -e "DISPLAY=${DISPLAY:-:0.0}" \
+    -e "OSX_COMMANDS=/bin/bash -c \"pwd && uname -a\"" \
+    sickcodes/docker-osx:auto
+
+# Boots in a minute or two!
+```
+
+### Further examples
+
+There's a myriad of other potential use cases that can work perfectly with Docker-OSX, some of which you'll see below!
+
+### Building a headless OSX container
+
+For a headless container, **remove** the following two lines from your `docker run` command:
+
+```
+    # -v /tmp/.X11-unix:/tmp/.X11-unix \
+    # -e "DISPLAY=${DISPLAY:-:0.0}" \
+```
+
+#### Building a headless container from a custom image [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/naked?label=sickcodes%2Fdocker-osx%3Anaked](https://img.shields.io/docker/image-size/sickcodes/docker-osx/naked?label=sickcodes%2Fdocker-osx%3Anaked)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
+
+This is particularly helpful for CI/CD pipelines.
+
+```bash
+# run your own image headless + SSH
+docker run -it \
+    --device /dev/kvm \
+    -p 50922:10022 \
+    -v "${PWD}/mac_hdd_ng.img:/image" \
+    sickcodes/docker-osx:naked
+```
+
+### Building a headless container which allows insecure VNC on localhost (!for local use only!)
+
+**Must change -it to -i to be able to interact with the QEMU console**
+
+**To exit a container using -i you must `docker kill <containerid>`. For example, to kill everything, `docker ps | xargs docker kill`.**
+
+Native QEMU VNC example
+
+```bash
+docker run -i \
+    --device /dev/kvm \
+    -p 50922:10022 \
+    -p 5999:5999 \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -e "DISPLAY=${DISPLAY:-:0.0}" \
+    -e EXTRA="-display none -vnc 0.0.0.0:99,password" \
+    sickcodes/docker-osx:big-sur
+
+# type `change vnc password` into the docker terminal and set a password
+# connect to localhost:5999 using VNC
+```
+
+**NOT TLS/HTTPS Encrypted at all!**
+
+Or `ssh -N root@1.1.1.1 -L  5999:127.0.0.1:5999`, where `1.1.1.1` is your remote server IP.
+
+(Note: if you close port 5999 and use the SSH tunnel, this becomes secure.)
+
+### Building a headless container to run remotely with secure VNC
+
+Add the following line:
+
+`-e EXTRA="-display none -vnc 0.0.0.0:99,password"`
+
+In the Docker terminal, press `enter` until you see `(qemu)`.
+
+Type `change vnc password`
+
+You also need the container IP: `docker inspect <containerid> | jq -r '.[0].NetworkSettings.IPAddress'`
+
+Or `ip n` will usually show the container IP first.
+
+Now VNC connect using the Docker container IP, for example `172.17.0.2:5999`
+
+Remote VNC over SSH: `ssh -N root@1.1.1.1 -L  5999:172.17.0.2:5999`, where `1.1.1.1` is your remote server IP and `172.17.0.2` is your LAN container IP.
+
+Now you can direct connect VNC to any container built with this command!
+
+### I'd like to use SPICE instead of VNC
+
+Optionally, you can enable the SPICE protocol, which allows use of `remote-viewer` to access your OSX container rather than VNC.
+
+Note: `-disable-ticketing` will allow unauthenticated access to the VM. See the [spice manual](https://www.spice-space.org/spice-user-manual.html) for help setting up authenticated access ("Ticketing").
+
+```bash
+  docker run \
+    --device /dev/kvm \
+    -p 50922:10022 \
+    -e "DISPLAY=${DISPLAY:-:0.0}" \
+    -e EXTRA="-monitor telnet::45454,server,nowait -nographic -serial null -spice disable-ticketing,port=3001" \
+    mycustomimage
+```
+
+Then simply do `remote-viewer spice://localhost:3001` and add `--spice-debug` for debugging.
+
+#### Creating images based on an already configured and set up container
+```bash
+# You can create an image of an already configured and setup container.
+# This allows you to effectively duplicate a system.
+# To do this, run the following commands
+
+# make note of your container id
+docker ps --all
+docker commit containerid newImageName
+
+# To run this image do the following
+docker run \
+    --device /dev/kvm \
+    --device /dev/snd \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    newImageName
+```
+
+#### Run Catalina Pre-Installed [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/auto?label=sickcodes%2Fdocker-osx%3Aauto](https://img.shields.io/docker/image-size/sickcodes/docker-osx/auto?label=sickcodes%2Fdocker-osx%3Aauto)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
+
+```bash
+docker pull sickcodes/docker-osx:auto
+
+# boot directly into a real OS X shell with a visual display [NOT HEADLESS]
+docker run -it \
+    --device /dev/kvm \
+    -p 50922:10022 \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -e "DISPLAY=${DISPLAY:-:0.0}" \
+    sickcodes/docker-osx:auto
+
+# username is user
+# passsword is alpine
+```
+
+```bash
+docker pull sickcodes/docker-osx:auto
+
+# boot directly into a real OS X shell with no display (Xvfb) [HEADLESS]
+docker run -it \
+    --device /dev/kvm \
+    -p 50922:10022 \
+    sickcodes/docker-osx:auto
+
+# username is user
+# passsword is alpine
+# Wait 2-3 minutes until you drop into the shell.
+```
+
+#### Run the original version of Docker-OSX
+
+```bash
+
+docker pull sickcodes/docker-osx:latest
+
+docker run -it \
+    --device /dev/kvm \
+    --device /dev/snd \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -e "DISPLAY=${DISPLAY:-:0.0}" \
+    sickcodes/docker-osx:latest
+
+# press CTRL + G if your mouse gets stuck
+# scroll down to troubleshooting if you have problems
+# need more RAM and SSH on localhost -p 50922?
+```
+
+#### Run but enable SSH in OS X (Original Version)!
+
+```bash
+docker run -it \
+    --device /dev/kvm \
+    --device /dev/snd \
+    -p 50922:10022 \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -e "DISPLAY=${DISPLAY:-:0.0}" \
+    sickcodes/docker-osx:latest
+
+# turn on SSH after you've installed OS X in the "Sharing" settings.
+ssh user@localhost -p 50922
+```
+
+#### Autoboot into OS X after you've installed everything
+
+Add the extra option `-e NOPICKER=true`.
+
+Old machines:
+
+```bash
+# find your containerID
+docker ps
+
+# move the no picker script on top of the Launch script
+# NEW CONTAINERS
+docker exec containerID mv ./Launch-nopicker.sh ./Launch.sh
+
+# VNC-VERSION-CONTAINER
+docker exec containerID mv ./Launch-nopicker.sh ./Launch_custom.sh
+
+# LEGACY CONTAINERS
+docker exec containerID bash -c "grep -v InstallMedia ./Launch.sh > ./Launch-nopicker.sh
+chmod +x ./Launch-nopicker.sh
+sed -i -e s/OpenCore\.qcow2/OpenCore\-nopicker\.qcow2/ ./Launch-nopicker.sh
+"
+```


### PR DESCRIPTION
Hi there! I wanted to clean up the base docs a bit based on my experience getting started with Docker-OSX. 

What's changed
- added some links to various closed issues
- fixed dead links
- unified internal link formatting (#the-section-name allows links to work locally and in forks, not just in this repo)
- moved around sections for flow and resized some headings

If this is a lot, feel free to request changes or modify yourself, otherwise I can split this into multiple PRs by commit :slightly_smiling_face: 