### PR TITLE
Add LIBGUESTFS debug & trace commands, exit on fail. Update credits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Version|Date|Notes|
 |---|---|---|
+|   |2021-04-18|Add LIBGUESTFS debug & trace commands, exit on fail when creating bootdisks. Silence touch errors.| 
 |4.3|2021-03-24|Enable interactive QEMU again. Remove envsubst since we are already using bash... Add set -x flag| 
 |4.2|2021-03-24|Add all ENV variables to each dockerfile for readability. Add RAM allocation buffer and cache drop bug fix. Add kvm and libvirt groups. Add `IMAGE_FORMAT=qcow2` to allow `IMAGE_FORMAT=raw` too.|
 |   |2021-03-19|Use RAM=3 as the default RAM allocation. Add instructions to clear buff/cache.|

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -74,6 +74,6 @@ This project now uses the fantastic OpenCore bootloader from the community OpenC
 
 [@panos](https://github.com/panos) - Made further improvements to the README #219
 
-[@a10kiloham] - Dockerfile for :naked image with VNC support #245 
+[@a10kiloham](https://github.com/a10kiloham) - Dockerfile for :naked image with VNC support #245 
 
-[@a10kiloham] - Adding Bluebubbles as an example use case #250 
+[@a10kiloham](https://github.com/a10kiloham) - Adding Bluebubbles as an example use case #250 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -2,7 +2,11 @@
 
 ## Upstream Acknowledgements:
 
-This project uses OSX-KVM from https://github.com/kholia/OSX-KVM/ and fully appreciates the work done by [@Kholia](https://github.com/Kholia) and all the contributors who are listed: [https://github.com/kholia/OSX-KVM/blob/master/CREDITS.md](https://github.com/kholia/OSX-KVM/blob/master/CREDITS.md)
+This project uses OSX-KVM from https://github.com/kholia/OSX-KVM and fully appreciates the work done by [@Kholia](https://github.com/Kholia) and all the contributors who are listed: [https://github.com/kholia/OSX-KVM/blob/master/CREDITS.md](https://github.com/kholia/OSX-KVM/blob/master/CREDITS.md)
+
+This project also uses KVM-OpenCore from https://github.com/Leoyzen/KVM-Opencore and fully appreciates the work done by [@Leoyzen](https://github.com/Leoyzen).
+
+We use a special fork by [Nicholas Sherlock](https://www.nicksherlock.com/) of KVM-Opencore https://github.com/thenickdude/KVM-Opencore and thank Nick for his awesome upstream work!
 
 This project now uses the fantastic OpenCore bootloader from the community OpenCore project: https://github.com/acidanthera/OpenCorePkg. You can join their [Subreddit here](https://www.reddit.com/r/hackintosh/)!
 
@@ -69,3 +73,7 @@ This project now uses the fantastic OpenCore bootloader from the community OpenC
 [@ggjulio](https://github.com/ggjulio) - Restarting an "auto" container #216
 
 [@panos](https://github.com/panos) - Made further improvements to the README #219
+
+[@a10kiloham] - Dockerfile for :naked image with VNC support #245 
+
+[@a10kiloham] - Adding Bluebubbles as an example use case #250 

--- a/Dockerfile
+++ b/Dockerfile
@@ -185,9 +185,6 @@ RUN [[ "${VERSION%%.*}" -ge 11 ]] && { wget "${FETCH_MAC_OS_RAW}" \
         && rm -f BaseSystem.dmg \
     ; } || true
 
-# > Launch.sh
-# > Docker-OSX.xml
-
 WORKDIR /home/arch/OSX-KVM
 
 ARG LINUX=true
@@ -289,6 +286,9 @@ ENV RAM=3
 ENV WIDTH=1920
 ENV HEIGHT=1080
 
+# libguestfs verbose
+ENV LIBGUESTFS_DEBUG=1
+ENV LIBGUESTFS_TRACE=1
 
 VOLUME ["/tmp/.X11-unix"]
 
@@ -311,7 +311,7 @@ VOLUME ["/tmp/.X11-unix"]
 # the default serial numbers are already contained in ./OpenCore-Catalina/OpenCore.qcow2
 # And the default serial numbers
 
-CMD sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" || true \
+CMD sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" 2>/dev/null || true \
     ; sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" || true \
     ; [[ "${NOPICKER}" == true ]] && { \
         sed -i '/^.*InstallMedia.*/d' Launch.sh \
@@ -328,7 +328,7 @@ CMD sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" || true 
             --height "${HEIGHT:-1080}" \
             --output-bootdisk "${BOOTDISK:=/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" \
             --output-env "${ENV:=/env}" \
-    ; } \
+    || exit 1 ; } \
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
             source "${ENV:=/env}" 2>/dev/null \
             ; ./Docker-OSX/osx-serial-generator/generate-specific-bootdisk.sh \
@@ -341,7 +341,7 @@ CMD sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" || true 
             --width "${WIDTH:-1920}" \
             --height "${HEIGHT:-1080}" \
             --output-bootdisk "${BOOTDISK:=/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" \
-    ; } \
+    || exit 1 ; } \
     ; ./enable-ssh.sh && /bin/bash -c ./Launch.sh
 
 # virt-manager mode: eta son

--- a/Dockerfile.auto
+++ b/Dockerfile.auto
@@ -170,6 +170,10 @@ ENV RAM=3
 ENV WIDTH=1920
 ENV HEIGHT=1080
 
+# libguestfs verbose
+ENV LIBGUESTFS_DEBUG=1
+ENV LIBGUESTFS_TRACE=1
+
 ENV TERMS_OF_USE=i_agree
 
 ENV BOILERPLATE="By using this Dockerfile, you hereby agree that you are a security reseacher or developer and agree to use this Dockerfile to make the world a safer place. Examples include: making your apps safer, finding your mobile phone, compiling security products, etc. You understand that Docker-OSX is an Open Source project, which is released to the public under the GNU Pulic License version 3 and above. You acknowledge that the Open Source project is absolutely unaffiliated with any third party, in any form whatsoever. Any trademarks or intelectual property which happen to be mentioned anywhere in or around the project are owned by their respective owners. By using this Dockerfile, you agree to agree to the EULA of each piece of upstream or downstream software. The following code is released for the sole purpose of security research, under the GNU Public License version 3. If you are concerned about the licensing, please note that this project is not AGPL. A copy of the license is available online: https://github.com/sickcodes/Docker-OSX/blob/master/LICENSE. In order to use the following Dockerfile you must read and understand the terms. Once you have read the terms, use the -e TERMS_OF_USE=i_agree or -e TERMS_OF_USE=i_disagree"
@@ -177,7 +181,7 @@ ENV BOILERPLATE="By using this Dockerfile, you hereby agree that you are a secur
 CMD echo "${BOILERPLATE}" \
     ; [[ "${TERMS_OF_USE}" = i_agree ]] || exit 1 \
     ; echo "Disk is being copied between layers... Please wait a minute..." \
-    ; sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" || true \
+    ; sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" 2>/dev/null || true \
     ; sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" || true \
     ; [[ "${NOPICKER}" == true ]] && { \
         sed -i '/^.*InstallMedia.*/d' Launch.sh \
@@ -194,7 +198,7 @@ CMD echo "${BOILERPLATE}" \
             --height "${HEIGHT:-1080}" \
             --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" \
             --output-env "${ENV:=/env}" \
-    ; } \
+    || exit 1 ; } \
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
             source "${ENV:=/env}" 2>/dev/null \
             ; ./Docker-OSX/osx-serial-generator/generate-specific-bootdisk.sh \
@@ -207,7 +211,7 @@ CMD echo "${BOILERPLATE}" \
             --width "${WIDTH:-1920}" \
             --height "${HEIGHT:-1080}" \
             --output-bootdisk "${BOOTDISK:-/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}"  \
-    ; } \
+    || exit 1 ; } \
     ; { [[ "${DISPLAY}" = ':99' ]] || [[ "${HEADLESS}" == true ]] ; } && { \
         nohup Xvfb :99 -screen 0 1920x1080x16 \
         & until [[ "$(xrandr --query 2>/dev/null)" ]]; do sleep 1 ; done \

--- a/Dockerfile.naked
+++ b/Dockerfile.naked
@@ -142,7 +142,11 @@ ENV RAM=3
 ENV WIDTH=1920
 ENV HEIGHT=1080
 
-CMD sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" || true \
+# libguestfs verbose
+ENV LIBGUESTFS_DEBUG=1
+ENV LIBGUESTFS_TRACE=1
+
+CMD sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" 2>/dev/null || true \
     ; sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" || true \
     ; { [[ "${DISPLAY}" = ':99' ]] || [[ "${HEADLESS}" == true ]] ; } && { \
         nohup Xvfb :99 -screen 0 1920x1080x16 \
@@ -163,7 +167,7 @@ CMD sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" || true 
             --height "${HEIGHT:-1080}" \
             --output-bootdisk "${BOOTDISK:=/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" \
             --output-env "${ENV:=/env}" \
-    ; } \
+    || exit 1 ; } \
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
             source "${ENV:=/env}" 2>/dev/null \
             ; ./Docker-OSX/osx-serial-generator/generate-specific-bootdisk.sh \
@@ -176,5 +180,5 @@ CMD sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" || true 
             --width "${WIDTH:-1920}" \
             --height "${HEIGHT:-1080}" \
             --output-bootdisk "${BOOTDISK:=/home/arch/OSX-KVM/OpenCore-Catalina/OpenCore.qcow2}" \
-    ; } \
+    || exit 1 ; } \
     ; ./enable-ssh.sh && /bin/bash -c ./Launch.sh


### PR DESCRIPTION

Added to each Dockerfile
```dockerfile
# libguestfs verbose
ENV LIBGUESTFS_DEBUG=1
ENV LIBGUESTFS_TRACE=1
```

Added hard exits if generating serials fails to prevent unrelated issues
```bash
#    ; } \
    || exit 1 ; } \
```

Silenced arbitrary touch command and start of each `CMD`
