### PR TITLE
Downgrade file command for libguestfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -197,6 +197,11 @@ RUN if [[ "${LINUX}" == true ]]; then \
         && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine." \
     ; fi
 
+RUN yes | sudo pacman -U https://archive.archlinux.org/packages/f/file/file-5.39-1-x86_64.pkg.tar.zst \
+    && patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
+    && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
+    && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine."
+
 # optional --build-arg to change branches for testing
 ARG BRANCH=master
 ARG REPO='https://github.com/sickcodes/Docker-OSX.git'


### PR DESCRIPTION
Bug for Arch is here: https://bbs.archlinux.org/viewtopic.php?pid=1967285#p1967285

libguestfs mailing list bug is here: https://www.mail-archive.com/libguestfs@redhat.com/msg21721.html

More bug info: https://bugs.astron.com/view.php?id=253

And here: https://bugzilla.redhat.com/show_bug.cgi?id=1945122

Solution here: https://github.com/sickcodes/Docker-OSX/issues/244#issuecomment-821990631

Thank you [@aronzvi](https://github.com/aronzvi) - Fixed Failed to boot OSX with GENERATE_UNIQUE #244

Fixes #244

Fixes  Rare bug: libcrc32c.ko causes libguestfs crash #238 
