### PR TITLE
Change call function to Popen

### DIFF
--- a/fetch-macOS.py
+++ b/fetch-macOS.py
@@ -87,8 +87,8 @@ class ReplicationError(Exception):
 
 
 def cmd_exists(cmd):
-    return subprocess.call("type " + cmd, shell=True,
-                           stdout=subprocess.PIPE, stderr=subprocess.PIPE) == 0
+    proc subprocess.Popen("type " + cmd, shell=True,
+                           stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 
 def replicate_url(full_url,

--- a/fetch-macOS.py
+++ b/fetch-macOS.py
@@ -87,7 +87,7 @@ class ReplicationError(Exception):
 
 
 def cmd_exists(cmd):
-    proc subprocess.Popen("type " + cmd, shell=True,
+    return subprocess.Popen("type " + cmd, shell=True,
                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 


### PR DESCRIPTION
The call function can deadlock if the child process prints larger output. Use Popen with the communicate() method with you need pipes. If you switch to Popen, you'll get cleaner debugging.