### PR TITLE
Retire glibc patch. Retire file command patch. Add `bootmenu=on`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Version|Date|Notes|
 |---|---|---|
+|5.0|2021-07-25|Retire glibc patch. Retire file command patch. Add bootmenu=on.|
 |   |2021-07-08|Add CPUID_FLAGS to edit the CPUID flags on the fly.|
 |4.4|2021-05-06|Prepare nakedvnc for hub.docker.com. Add `ENV BOOT_ARGS=` to supply additon boot arguments, for example, `vmx,rdtscp`. Add `ENV CPU=Penryn` to allow changes to the CPU emulation, for example, `Skylake-Client`, or see [more examples here](https://manpages.ubuntu.com/manpages/disco/man7/qemu-cpu-models.7.html).| 
 |   |2021-05-04|Disable arbitrary chown warning| 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -22,7 +22,7 @@ This project now uses the fantastic OpenCore bootloader from the community OpenC
 
 [@qcasey](https://github.com/qcasey) - Removed unnecessary yay in Remove yay dependancy #40 
 
-[@tlierdotfr](https://github.com/tlierdotfr) - Reduce number of layers in Dockerfile  
+[@tlierdotfr](https://github.com/tlierdotfr) - Reduce number of layers in Dockerfile 
 
 [@Julioevm](https://github.com/Julioevm) - Update docker-compose.yml #57
 
@@ -46,7 +46,7 @@ This project now uses the fantastic OpenCore bootloader from the community OpenC
 
 [@PeterDaveHello](https://github.com/PeterDaveHello) - Reduce image size by setting git clone depth #110
 
-[@PeterDaveHello](https://github.com/PeterDaveHello) -  Reduce Dockerfile instructions and Docker image layers #112
+[@PeterDaveHello](https://github.com/PeterDaveHello) - Reduce Dockerfile instructions and Docker image layers #112
 
 [@weskerfoot](https://github.com/weskerfoot) Docs updates: usb passthrough, headless mode, disk space reduction guide #113
 
@@ -68,7 +68,7 @@ This project now uses the fantastic OpenCore bootloader from the community OpenC
 
 [@TheHackerCoding](https://github.com/TheHackerCoding) - Typo in README.md #194
 
-[@panos](https://github.com/panos) -  Improved README #212 
+[@panos](https://github.com/panos) - Improved README #212 
 
 [@ggjulio](https://github.com/ggjulio) - Restarting an "auto" container #216
 
@@ -80,6 +80,12 @@ This project now uses the fantastic OpenCore bootloader from the community OpenC
 
 [@aronzvi](https://github.com/aronzvi) - Fixed Failed to boot OSX with GENERATE_UNIQUE #244
 
-[@tinjaw](https://github.com/tinjaw) -  Fixed Type #258
+[@tinjaw](https://github.com/tinjaw) - Fixed Type #258
 
 [@m-zheng](https://github.com/m-zheng) -  Update README.md #260 
+
+[@johnjhacking](https://github.com/johnjhacking) - Change call function to Popen #288 
+
+[@allansrc](https://github.com/allansrc) - Update Doc detail for run on WLS #318 
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 #
 # Title:            Docker-OSX (Mac on Docker)
 # Author:           Sick.Codes https://twitter.com/sickcodes
-# Version:          4.4
+# Version:          5.0
 # License:          GPLv3+
 # Repository:       https://github.com/sickcodes/Docker-OSX
 # Website:          https://sick.codes
@@ -67,12 +67,6 @@ ARG RANKMIRRORS
 ARG MIRROR_COUNTRY=US
 ARG MIRROR_COUNT=10
 
-# TEMP-FIX for pacman issue
-RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
-    && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
-    && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine."
-# TEMP-FIX for pacman issue
-
 RUN if [[ "${RANKMIRRORS}" ]]; then \
         { pacman -Sy wget --noconfirm || pacman -Syu wget --noconfirm ; } \
         ; wget -O ./rankmirrors "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/rankmirrors" \
@@ -98,12 +92,6 @@ RUN pacman -Syu git zip vim nano alsa-utils openssh --noconfirm \
     && tee -a /etc/sudoers <<< 'arch ALL=(ALL) NOPASSWD: ALL' \
     && mkdir /home/arch \
     && chown arch:arch /home/arch
-
-# TEMP-FIX for pacman issue
-RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
-    && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
-    && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine."
-# TEMP-FIX for pacman issue
 
 # allow ssh to container
 RUN mkdir -m 700 /root/.ssh
@@ -154,15 +142,6 @@ RUN touch enable-ssh.sh \
 RUN yes | sudo pacman -Syu qemu libvirt dnsmasq virt-manager bridge-utils openresolv jack ebtables edk2-ovmf netctl libvirt-dbus wget --overwrite --noconfirm \
     && yes | sudo pacman -Scc
 
-# TEMP-FIX for pacman issue
-RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
-    && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
-    && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine."
-# TEMP-FIX for pacman issue
-
-# RUN sudo systemctl enable libvirtd.service
-# RUN sudo systemctl enable virtlogd.service
-
 WORKDIR /home/arch/OSX-KVM
 
 RUN wget https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/fetch-macOS.py
@@ -192,17 +171,7 @@ ARG LINUX=true
 # required to use libguestfs inside a docker container, to create bootdisks for docker-osx on-the-fly
 RUN if [[ "${LINUX}" == true ]]; then \
         sudo pacman -Syu linux libguestfs --noconfirm \
-        && patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
-        && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
-        && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine." \
     ; fi
-
-# TEMP-FIX for file 5.40 libguestfs issue
-RUN yes | sudo pacman -U https://archive.archlinux.org/packages/f/file/file-5.39-1-x86_64.pkg.tar.zst \
-    && patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
-    && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
-    && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine."
-# TEMP-FIX for file 5.40 libguestfs issue
 
 # optional --build-arg to change branches for testing
 ARG BRANCH=master
@@ -224,7 +193,7 @@ RUN touch Launch.sh \
     && tee -a Launch.sh <<< '-smp ${CPU_STRING:-${SMP:-4},cores=${CORES:-4}} \' \
     && tee -a Launch.sh <<< '-usb -device usb-kbd -device usb-tablet \' \
     && tee -a Launch.sh <<< '-device isa-applesmc,osk=ourhardworkbythesewordsguardedpleasedontsteal\(c\)AppleComputerInc \' \
-    && tee -a Launch.sh <<< '-drive if=pflash,format=raw,readonly,file=/home/arch/OSX-KVM/OVMF_CODE.fd \' \
+    && tee -a Launch.sh <<< '-drive if=pflash,format=raw,readonly=on,file=/home/arch/OSX-KVM/OVMF_CODE.fd \' \
     && tee -a Launch.sh <<< '-drive if=pflash,format=raw,file=/home/arch/OSX-KVM/OVMF_VARS-1024x768.fd \' \
     && tee -a Launch.sh <<< '-smbios type=2 \' \
     && tee -a Launch.sh <<< '-audiodev ${AUDIO_DRIVER:-alsa},id=hda -device ich9-intel-hda -device hda-duplex,audiodev=hda \' \
@@ -238,6 +207,7 @@ RUN touch Launch.sh \
     && tee -a Launch.sh <<< '-netdev user,id=net0,hostfwd=tcp::${INTERNAL_SSH_PORT:-10022}-:22,hostfwd=tcp::${SCREEN_SHARE_PORT:-5900}-:5900,${ADDITIONAL_PORTS} \' \
     && tee -a Launch.sh <<< '-device ${NETWORKING:-vmxnet3},netdev=net0,id=net0,mac=${MAC_ADDRESS:-52:54:00:09:49:17} \' \
     && tee -a Launch.sh <<< '-monitor stdio \' \
+    && tee -a Launch.sh <<< '-boot menu=on \' \
     && tee -a Launch.sh <<< '-vga vmware \' \
     && tee -a Launch.sh <<< '${EXTRA:-}'
 

--- a/Dockerfile.auto
+++ b/Dockerfile.auto
@@ -70,12 +70,6 @@ RUN if [[ "${RANKMIRRORS}" ]]; then \
     ; fi \
     ; yes | pacman -Scc
 
-# TEMP-FIX for pacman issue
-RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
-    && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
-    && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine."
-# TEMP-FIX for pacman issue
-
 RUN pacman -Syu xorg-server-xvfb wget xterm xorg-xhost xorg-xrandr sshpass --noconfirm \
     && if [[ "${SCROT}" ]]; then \
         pacman -Syu scrot base-devel --noconfirm \
@@ -92,19 +86,6 @@ RUN pacman -Syu xorg-server-xvfb wget xterm xorg-xhost xorg-xrandr sshpass --noc
         && chmod +x /usr/bin/scrotcat \
     ; fi \
     ; yes | pacman -Scc
-
-# TEMP-FIX for pacman issue
-RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
-    && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
-    && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine."
-# TEMP-FIX for pacman issue
-
-# TEMP-FIX for file 5.40 libguestfs issue
-RUN yes | sudo pacman -U https://archive.archlinux.org/packages/f/file/file-5.39-1-x86_64.pkg.tar.zst \
-    && patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
-    && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
-    && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine."
-# TEMP-FIX for file 5.40 libguestfs issue
 
 USER arch
 

--- a/Dockerfile.naked
+++ b/Dockerfile.naked
@@ -56,12 +56,6 @@ RUN if [[ "${RANKMIRRORS}" ]]; then { pacman -Sy wget --noconfirm || pacman -Syu
     && tee -a /etc/pacman.d/mirrorlist <<< 'Server = https://mirror.rackspace.com/archlinux/$repo/os/$arch' \
     && cat /etc/pacman.d/mirrorlist ; fi
 
-# TEMP-FIX for pacman issue
-RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
-    && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
-    && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine."
-# TEMP-FIX for pacman issue
-
 # For taking screenshots of the Xfvb screen, useful during development.
 ARG SCROT
 
@@ -81,19 +75,6 @@ RUN pacman -Syu xorg-server-xvfb wget xterm xorg-xhost xorg-xrandr sshpass --noc
         && chmod +x /usr/bin/scrotcat \
     ; fi \
     ; yes | pacman -Scc
-
-# TEMP-FIX for pacman issue
-RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
-    && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
-    && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine."
-# TEMP-FIX for pacman issue
-
-# TEMP-FIX for file 5.40 libguestfs issue
-RUN yes | sudo pacman -U https://archive.archlinux.org/packages/f/file/file-5.39-1-x86_64.pkg.tar.zst \
-    && patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
-    && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
-    && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine."
-# TEMP-FIX for file 5.40 libguestfs issue
 
 USER arch
 


### PR DESCRIPTION
Updated PR of https://github.com/sickcodes/Docker-OSX/pull/159

Plus `file` bug. Assuming fixed by now...

> We currently have a dirty fix that looks like this:
> 
> # TEMP-FIX for pacman issue
> RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst \
>     && curl -LO "https://raw.githubusercontent.com/sickcodes/Docker-OSX/master/${patched_glibc}" \
>     && bsdtar -C / -xvf "${patched_glibc}" || echo "Everything is fine."
> # TEMP-FIX for pacman issue
> 
> This PR is just a reminder to repeat build tests until it's fixed upstream as noted:
> 
> #144
> 
> #150
> 
> #152