### PR TITLE
Fix command to launch sickcodes/docker-osx:auto

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -95,3 +95,5 @@ This project now uses the fantastic OpenCore bootloader from the community OpenC
 [@Silfalion](https://github.com/Silfalion) - [https://github.com/Silfalion/Iphone_docker_osx_passthrough](https://github.com/Silfalion/Iphone_docker_osx_passthrough)
 
 [@Buthrakaur](https://github.com/Buthrakaur) readme - improve instructions for running on windows #361
+
+[@eggplants](https://github.com/eggplants)  Fix command to launch sickcodes/docker-osx:auto #366 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ docker run -it \
     -p 50922:10022 \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     -e "DISPLAY=${DISPLAY:-:0.0}" \
+    -e GENERATE_UNIQUE=true \
     sickcodes/docker-osx:auto
 
 # username is user


### PR DESCRIPTION
I added option `-e GENERATE_UNIQUE=true` to README.md's example.