### PR TITLE
Fixes #368 Downgrade kernel for the subsystem to 5.12, and hold back libguestfs at libguestfs-1.44.1

### DIFF
--- a/Dockerfile.auto
+++ b/Dockerfile.auto
@@ -92,19 +92,29 @@ USER arch
 
 ENV USER arch
 
-# 5.13 problem
+
+#### libguestfs versioning
+
+# 5.13+ problem resolved by building the qcow2 against 5.12 using libguestfs-1.44.1-6
+
 ENV SUPERMIN_KERNEL=/boot/vmlinuz-linux
-
 ENV SUPERMIN_MODULES=/lib/modules/5.12.14-arch1-1
-
 ENV SUPERMIN_KERNEL_VERSION=5.12.14-arch1-1
+ENV KERNEL_PACKAGE_URL=https://archive.archlinux.org/packages/l/linux/linux-5.12.14.arch1-1-x86_64.pkg.tar.zst
+ENV LIBGUESTFS_PACKAGE_URL=https://archive.archlinux.org/packages/l/libguestfs/libguestfs-1.44.1-6-x86_64.pkg.tar.zst
 
-RUN sudo pacman -Rns linux --noconfirm \
-    ; sudo pacman -Syy \
-    ; sudo pacman -S mkinitcpio --noconfirm \
-    ; sudo pacman -U https://archive.archlinux.org/packages/l/linux/linux-5.12.14.arch1-1-x86_64.pkg.tar.zst --noconfirm \
-    ; sudo rm -rf /var/tmp/.guestfs-* \
-    ; libguestfs-test-tool
+ARG LINUX=true
+
+# required to use libguestfs inside a docker container, to create bootdisks for docker-osx on-the-fly
+RUN if [[ "${LINUX}" == true ]]; then \
+        sudo pacman -U "${KERNEL_PACKAGE_URL}" --noconfirm \
+        ; sudo pacman -U "${LIBGUESTFS_PACKAGE_URL}" --noconfirm \
+        ; sudo libguestfs-test-tool \
+        ; sudo rm -rf /var/tmp/.guestfs-* \
+    ; fi
+
+####
+
 
 WORKDIR /home/arch/OSX-KVM
 

--- a/Dockerfile.monterey
+++ b/Dockerfile.monterey
@@ -97,19 +97,26 @@ USER arch
 
 ENV USER arch
 
-# 5.13 problem
+
+#### libguestfs versioning
+
+# 5.13+ problem resolved by building the qcow2 against 5.12 using libguestfs-1.44.1-6
+
 ENV SUPERMIN_KERNEL=/boot/vmlinuz-linux
-
 ENV SUPERMIN_MODULES=/lib/modules/5.12.14-arch1-1
-
 ENV SUPERMIN_KERNEL_VERSION=5.12.14-arch1-1
+ENV KERNEL_PACKAGE_URL=https://archive.archlinux.org/packages/l/linux/linux-5.12.14.arch1-1-x86_64.pkg.tar.zst
+ENV LIBGUESTFS_PACKAGE_URL=https://archive.archlinux.org/packages/l/libguestfs/libguestfs-1.44.1-6-x86_64.pkg.tar.zst
 
-RUN sudo pacman -Rns linux --noconfirm \
-    ; sudo pacman -Syy \
-    ; sudo pacman -S mkinitcpio --noconfirm \
-    ; sudo pacman -U https://archive.archlinux.org/packages/l/linux/linux-5.12.14.arch1-1-x86_64.pkg.tar.zst --noconfirm \
-    ; sudo rm -rf /var/tmp/.guestfs-* \
-    ; libguestfs-test-tool
+ARG LINUX=true
+
+# required to use libguestfs inside a docker container, to create bootdisks for docker-osx on-the-fly
+RUN if [[ "${LINUX}" == true ]]; then \
+        sudo pacman -U "${KERNEL_PACKAGE_URL}" --noconfirm \
+        ; sudo pacman -U "${LIBGUESTFS_PACKAGE_URL}" --noconfirm \
+        ; sudo libguestfs-test-tool \
+        ; sudo rm -rf /var/tmp/.guestfs-* \
+    ; fi
 
 ####
 

--- a/Dockerfile.naked
+++ b/Dockerfile.naked
@@ -81,19 +81,29 @@ USER arch
 
 ENV USER arch
 
-# 5.13 problem
+
+#### libguestfs versioning
+
+# 5.13+ problem resolved by building the qcow2 against 5.12 using libguestfs-1.44.1-6
+
 ENV SUPERMIN_KERNEL=/boot/vmlinuz-linux
-
 ENV SUPERMIN_MODULES=/lib/modules/5.12.14-arch1-1
-
 ENV SUPERMIN_KERNEL_VERSION=5.12.14-arch1-1
+ENV KERNEL_PACKAGE_URL=https://archive.archlinux.org/packages/l/linux/linux-5.12.14.arch1-1-x86_64.pkg.tar.zst
+ENV LIBGUESTFS_PACKAGE_URL=https://archive.archlinux.org/packages/l/libguestfs/libguestfs-1.44.1-6-x86_64.pkg.tar.zst
 
-RUN sudo pacman -Rns linux --noconfirm \
-    ; sudo pacman -Syy \
-    ; sudo pacman -S mkinitcpio --noconfirm \
-    ; sudo pacman -U https://archive.archlinux.org/packages/l/linux/linux-5.12.14.arch1-1-x86_64.pkg.tar.zst --noconfirm \
-    ; sudo rm -rf /var/tmp/.guestfs-* \
-    ; libguestfs-test-tool
+ARG LINUX=true
+
+# required to use libguestfs inside a docker container, to create bootdisks for docker-osx on-the-fly
+RUN if [[ "${LINUX}" == true ]]; then \
+        sudo pacman -U "${KERNEL_PACKAGE_URL}" --noconfirm \
+        ; sudo pacman -U "${LIBGUESTFS_PACKAGE_URL}" --noconfirm \
+        ; sudo libguestfs-test-tool \
+        ; sudo rm -rf /var/tmp/.guestfs-* \
+    ; fi
+
+####
+
 
 WORKDIR /home/arch/OSX-KVM
 

--- a/Dockerfile.naked-auto
+++ b/Dockerfile.naked-auto
@@ -73,19 +73,28 @@ USER arch
 
 ENV USER arch
 
-# 5.13 problem
+#### libguestfs versioning
+
+# 5.13+ problem resolved by building the qcow2 against 5.12 using libguestfs-1.44.1-6
+
 ENV SUPERMIN_KERNEL=/boot/vmlinuz-linux
-
 ENV SUPERMIN_MODULES=/lib/modules/5.12.14-arch1-1
-
 ENV SUPERMIN_KERNEL_VERSION=5.12.14-arch1-1
+ENV KERNEL_PACKAGE_URL=https://archive.archlinux.org/packages/l/linux/linux-5.12.14.arch1-1-x86_64.pkg.tar.zst
+ENV LIBGUESTFS_PACKAGE_URL=https://archive.archlinux.org/packages/l/libguestfs/libguestfs-1.44.1-6-x86_64.pkg.tar.zst
 
-RUN sudo pacman -Rns linux --noconfirm \
-    ; sudo pacman -Syy \
-    ; sudo pacman -S mkinitcpio --noconfirm \
-    ; sudo pacman -U https://archive.archlinux.org/packages/l/linux/linux-5.12.14.arch1-1-x86_64.pkg.tar.zst --noconfirm \
-    ; sudo rm -rf /var/tmp/.guestfs-* \
-    ; libguestfs-test-tool
+ARG LINUX=true
+
+# required to use libguestfs inside a docker container, to create bootdisks for docker-osx on-the-fly
+RUN if [[ "${LINUX}" == true ]]; then \
+        sudo pacman -U "${KERNEL_PACKAGE_URL}" --noconfirm \
+        ; sudo pacman -U "${LIBGUESTFS_PACKAGE_URL}" --noconfirm \
+        ; sudo libguestfs-test-tool \
+        ; sudo rm -rf /var/tmp/.guestfs-* \
+    ; fi
+
+####
+
 
 WORKDIR /home/arch/OSX-KVM
 


### PR DESCRIPTION
See https://github.com/libguestfs/libguestfs/issues/73#issuecomment-954563203

Hack https://listman.redhat.com/archives/libguestfs/2021-October/msg00260.html

Upstream commit: https://github.com/libguestfs/libguestfs/commit/45de287447bb18d59749fbfc1ec5072413090109

```
    /* Since qemu 6.1, qemu-img create has requires a backing format (-F)
     * parameter if backing file (-b) is used (RHBZ#1998820).
     */
```

Alleged fix: https://bugzilla.redhat.com/show_bug.cgi?id=1998820

Solution: holding back libguestfs :+1: