### PR TITLE
NFS mount documentation, locking issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,7 +872,7 @@ Start the Docker-OSX container with the additional flag `--network host`
 Create and mount the nfs folder from the mac terminal:
 ```
 mkdir -p ~/mnt
-sudo mount -t nfs 10.0.2.2:/srv/nfs/share ~/mnt
+sudo mount_nfs -o locallocks 10.0.2.2:/srv/nfs/share ~/mnt
 ```
 
 ### Share USB Drive into macOS over QEMU


### PR DESCRIPTION
I ran into some issues when running software that was trying to lock files under the nfs folder. This was on Catalina and looks like this is a common issue with Mac -> Linux nfs. 

After digging into it, for my use case using the `locallocks` NFS option on the Mac client resolved it. The `locallocks` option means that locking is handled by the client. There would be problems if you actually need server side locking.