### PR TITLE
Persistent by default, but also optional.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "osx-serial-generator"]
 	path = osx-serial-generator
 	url = https://github.com/sickcodes/osx-serial-generator.git
+[submodule "OSX-KVM"]
+	path = OSX-KVM
+	url = https://github.com/kholia/OSX-KVM

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,14 +114,16 @@ RUN tee -a sshd_config <<< 'AllowTcpForwarding yes' \
 USER arch
 
 # download OSX-KVM
-# RUN git clone --recurse-submodules --depth 1 https://github.com/kholia/OSX-KVM.git /home/arch/OSX-KVM
-RUN git clone --recurse-submodules --depth 1 https://github.com/kholia/OSX-KVM.git /home/arch/OSX-KVM
+# RUN git clone --recurse-submodules --depth 1 https://github.com/kholia/OSX-KVM.git /home/arch/Docker-OSX/OSX-KVM
+RUN git clone --recurse-submodules --depth 1 https://github.com/sickcodes/Docker-OSX.git /home/arch/Docker-OSX
+
+# Create a symbolic link from OSX-KVM to submodule directory as we are using as a submodule instead now (redunancy proof)
+RUN ln -s /home/arch/Docker-OSX/OSX-KVM /home/arch/OSX-KVM
 
 # enable ssh
 # docker exec .... ./enable-ssh.sh
-USER arch
 
-WORKDIR /home/arch/OSX-KVM
+WORKDIR /home/arch/Docker-OSX
 
 RUN touch enable-ssh.sh \
     && chmod +x ./enable-ssh.sh \
@@ -143,7 +145,7 @@ RUN touch enable-ssh.sh \
 RUN yes | sudo pacman -Syu bc qemu libvirt dnsmasq virt-manager bridge-utils openresolv jack2 ebtables edk2-ovmf netctl libvirt-dbus wget --overwrite --noconfirm \
     && yes | sudo pacman -Scc
 
-WORKDIR /home/arch/OSX-KVM
+WORKDIR /home/arch/Docker-OSX/OSX-KVM
 
 # RUN wget https://raw.githubusercontent.com/kholia/OSX-KVM/master/fetch-macOS-v2.py
 
@@ -181,16 +183,16 @@ RUN touch Launch.sh \
     && tee -a Launch.sh <<< '-smp ${CPU_STRING:-${SMP:-4},cores=${CORES:-4}} \' \
     && tee -a Launch.sh <<< '-usb -device usb-kbd -device usb-tablet \' \
     && tee -a Launch.sh <<< '-device isa-applesmc,osk=ourhardworkbythesewordsguardedpleasedontsteal\(c\)AppleComputerInc \' \
-    && tee -a Launch.sh <<< '-drive if=pflash,format=raw,readonly=on,file=/home/arch/OSX-KVM/OVMF_CODE.fd \' \
-    && tee -a Launch.sh <<< '-drive if=pflash,format=raw,file=/home/arch/OSX-KVM/OVMF_VARS-1024x768.fd \' \
+    && tee -a Launch.sh <<< '-drive if=pflash,format=raw,readonly=on,file=/home/arch/Docker-OSX/OSX-KVM/OVMF_CODE.fd \' \
+    && tee -a Launch.sh <<< '-drive if=pflash,format=raw,file=/home/arch/Docker-OSX/OSX-KVM/OVMF_VARS-1024x768.fd \' \
     && tee -a Launch.sh <<< '-smbios type=2 \' \
     && tee -a Launch.sh <<< '-audiodev ${AUDIO_DRIVER:-alsa},id=hda -device ich9-intel-hda -device hda-duplex,audiodev=hda \' \
     && tee -a Launch.sh <<< '-device ich9-ahci,id=sata \' \
-    && tee -a Launch.sh <<< '-drive id=OpenCoreBoot,if=none,snapshot=on,format=qcow2,file=${BOOTDISK:-/home/arch/OSX-KVM/OpenCore/OpenCore.qcow2} \' \
+    && tee -a Launch.sh <<< '-drive id=OpenCoreBoot,if=none,snapshot=on,format=qcow2,file=${BOOTDISK:-/home/arch/Docker-OSX/OSX-KVM/OpenCore/OpenCore.qcow2} \' \
     && tee -a Launch.sh <<< '-device ide-hd,bus=sata.2,drive=OpenCoreBoot \' \
     && tee -a Launch.sh <<< '-device ide-hd,bus=sata.3,drive=InstallMedia \' \
-    && tee -a Launch.sh <<< '-drive id=InstallMedia,if=none,file=/home/arch/OSX-KVM/BaseSystem.img,format=${BASESYSTEM_FORMAT:-qcow2} \' \
-    && tee -a Launch.sh <<< '-drive id=MacHDD,if=none,file=${IMAGE_PATH:-/home/arch/OSX-KVM/mac_hdd_ng.img},format=${IMAGE_FORMAT:-qcow2} \' \
+    && tee -a Launch.sh <<< '-drive id=InstallMedia,if=none,file=/home/arch/Docker-OSX/OSX-KVM/BaseSystem.img,format=${BASESYSTEM_FORMAT:-qcow2} \' \
+    && tee -a Launch.sh <<< '-drive id=MacHDD,if=none,file=${IMAGE_PATH:-/home/arch/Docker-OSX/OSX-KVM/mac_hdd_ng.img},format=${IMAGE_FORMAT:-qcow2} \' \
     && tee -a Launch.sh <<< '-device ide-hd,bus=sata.4,drive=MacHDD \' \
     && tee -a Launch.sh <<< '-netdev user,id=net0,hostfwd=tcp::${INTERNAL_SSH_PORT:-10022}-:22,hostfwd=tcp::${SCREEN_SHARE_PORT:-5900}-:5900,${ADDITIONAL_PORTS} \' \
     && tee -a Launch.sh <<< '-device ${NETWORKING:-vmxnet3},netdev=net0,id=net0,mac=${MAC_ADDRESS:-52:54:00:09:49:17} \' \
@@ -257,8 +259,8 @@ ARG STOCK_WIDTH=1920
 ARG STOCK_HEIGHT=1080
 ARG STOCK_MASTER_PLIST_URL=https://raw.githubusercontent.com/sickcodes/osx-serial-generator/master/config-custom.plist
 ARG STOCK_MASTER_PLIST_URL_NOPICKER=https://raw.githubusercontent.com/sickcodes/osx-serial-generator/master/config-nopicker-custom.plist
-ARG STOCK_BOOTDISK=/home/arch/OSX-KVM/OpenCore/OpenCore.qcow2
-ARG STOCK_BOOTDISK_NOPICKER=/home/arch/OSX-KVM/OpenCore/OpenCore-nopicker.qcow2
+ARG STOCK_BOOTDISK=/home/arch/Docker-OSX/OSX-KVM/OpenCore/OpenCore.qcow2
+ARG STOCK_BOOTDISK_NOPICKER=/home/arch/Docker-OSX/OSX-KVM/OpenCore/OpenCore-nopicker.qcow2
 
 RUN ./Docker-OSX/osx-serial-generator/generate-specific-bootdisk.sh \
     --master-plist-url="${STOCK_MASTER_PLIST_URL}" \
@@ -285,7 +287,7 @@ RUN ./Docker-OSX/osx-serial-generator/generate-specific-bootdisk.sh \
     ; rm -rf /var/tmp/.guestfs-*
 
 ### symlink the old directory as upstream has renamed a directory. Symlinking purely for backwards compatability!
-RUN ln -s /home/arch/OSX-KVM/OpenCore /home/arch/OSX-KVM/OpenCore-Catalina || true
+RUN ln -s /home/arch/Docker-OSX/OSX-KVM/OpenCore /home/arch/Docker-OSX/OSX-KVM/OpenCore-Catalina || true
 ####
 
 #### SPECIAL RUNTIME ARGUMENTS BELOW
@@ -318,7 +320,7 @@ ENV GENERATE_UNIQUE=false
 # Boolean for generating a bootdisk with specific serials.
 ENV GENERATE_SPECIFIC=false
 
-ENV IMAGE_PATH=/home/arch/OSX-KVM/mac_hdd_ng.img
+ENV IMAGE_PATH=/home/arch/Docker-OSX/OSX-KVM/mac_hdd_ng.img
 ENV IMAGE_FORMAT=qcow2
 
 ENV KVM='accel=kvm:tcg'
@@ -366,9 +368,12 @@ CMD sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" 2>/dev/n
     ; sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" 2>/dev/null || true \
     ; [[ "${NOPICKER}" == true ]] && { \
         sed -i '/^.*InstallMedia.*/d' Launch.sh \
-        && export BOOTDISK="${BOOTDISK:=/home/arch/OSX-KVM/OpenCore/OpenCore-nopicker.qcow2}" \
+        && export BOOTDISK="${BOOTDISK:=/home/arch/Docker-OSX/OSX-KVM/OpenCore/OpenCore-nopicker.qcow2}" \
     ; } \
-    || export BOOTDISK="${BOOTDISK:=/home/arch/OSX-KVM/OpenCore/OpenCore.qcow2}" \
+    ; [[ "$(fdisk -l /image)" ]] && { \
+        && export IMAGE_PATH=/image \
+    ; } \
+    || export BOOTDISK="${BOOTDISK:=/home/arch/Docker-OSX/OSX-KVM/OpenCore/OpenCore.qcow2}" \
     ; [[ "${GENERATE_UNIQUE}" == true ]] && { \
         ./Docker-OSX/osx-serial-generator/generate-unique-machine-values.sh \
             --master-plist-url="${MASTER_PLIST_URL}" \
@@ -377,7 +382,7 @@ CMD sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" 2>/dev/n
             --bootdisks \
             --width "${WIDTH:-1920}" \
             --height "${HEIGHT:-1080}" \
-            --output-bootdisk "${BOOTDISK:=/home/arch/OSX-KVM/OpenCore/OpenCore.qcow2}" \
+            --output-bootdisk "${BOOTDISK:=/home/arch/Docker-OSX/OSX-KVM/OpenCore/OpenCore.qcow2}" \
             --output-env "${ENV:=/env}" \
     || exit 1 ; } \
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
@@ -391,7 +396,7 @@ CMD sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" 2>/dev/n
             --mac-address "${MAC_ADDRESS}" \
             --width "${WIDTH:-1920}" \
             --height "${HEIGHT:-1080}" \
-            --output-bootdisk "${BOOTDISK:=/home/arch/OSX-KVM/OpenCore/OpenCore.qcow2}" \
+            --output-bootdisk "${BOOTDISK:=/home/arch/Docker-OSX/OSX-KVM/OpenCore/OpenCore.qcow2}" \
     || exit 1 ; } \
     ; ./enable-ssh.sh && /bin/bash -c ./Launch.sh
 

--- a/Dockerfile.auto
+++ b/Dockerfile.auto
@@ -120,7 +120,7 @@ RUN sudo pacman -Syy \
 ####
 
 
-WORKDIR /home/arch/OSX-KVM
+WORKDIR /home/arch/Docker-OSX/OSX-KVM
 
 RUN mkdir -p ~/.ssh \
     && touch ~/.ssh/authorized_keys \
@@ -145,15 +145,15 @@ ARG IMAGE_URL='https://images.sick.codes/mac_hdd_ng_auto.img'
 
 RUN if [[ "${COMPLETE}" ]]; then \
         echo "Downloading 20GB image... This step might take a while... Press Ctrl+C if you want to abort." \
-        ; rm -f /home/arch/OSX-KVM/mac_hdd_ng.img \
-        && wget ${WGET_OPTIONS} -O /home/arch/OSX-KVM/mac_hdd_ng.img "${IMAGE_URL}" \
+        ; rm -f /home/arch/Docker-OSX/OSX-KVM/mac_hdd_ng.img \
+        && wget ${WGET_OPTIONS} -O /home/arch/Docker-OSX/OSX-KVM/mac_hdd_ng.img "${IMAGE_URL}" \
     ; fi
 
 
 ####
 
 # symlink the old directory, for redundancy
-RUN ln -s /home/arch/OSX-KVM/OpenCore /home/arch/OSX-KVM/OpenCore-Catalina || true
+RUN ln -s /home/arch/Docker-OSX/OSX-KVM/OpenCore /home/arch/Docker-OSX/OSX-KVM/OpenCore-Catalina || true
 
 ####
 
@@ -181,7 +181,7 @@ ENV GENERATE_UNIQUE=false
 # Boolean for generating a bootdisk with specific serials.
 ENV GENERATE_SPECIFIC=false
 
-ENV IMAGE_PATH=/home/arch/OSX-KVM/mac_hdd_ng.img
+ENV IMAGE_PATH=/home/arch/Docker-OSX/OSX-KVM/mac_hdd_ng.img
 ENV IMAGE_FORMAT=qcow2
 
 ENV KVM='accel=kvm:tcg'
@@ -222,9 +222,9 @@ CMD echo "${BOILERPLATE}" \
     ; sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" 2>/dev/null || true \
     ; [[ "${NOPICKER}" == true ]] && { \
         sed -i '/^.*InstallMedia.*/d' Launch.sh \
-        && export BOOTDISK="${BOOTDISK:=/home/arch/OSX-KVM/OpenCore/OpenCore-nopicker.qcow2}" \
+        && export BOOTDISK="${BOOTDISK:=/home/arch/Docker-OSX/OSX-KVM/OpenCore/OpenCore-nopicker.qcow2}" \
     ; } \
-    || export BOOTDISK="${BOOTDISK:=/home/arch/OSX-KVM/OpenCore/OpenCore.qcow2}" \
+    || export BOOTDISK="${BOOTDISK:=/home/arch/Docker-OSX/OSX-KVM/OpenCore/OpenCore.qcow2}" \
     ; [[ "${GENERATE_UNIQUE}" == true ]] && { \
         ./Docker-OSX/osx-serial-generator/generate-unique-machine-values.sh \
             --master-plist-url="${MASTER_PLIST_URL}" \
@@ -233,7 +233,7 @@ CMD echo "${BOILERPLATE}" \
             --bootdisks \
             --width "${WIDTH:-1920}" \
             --height "${HEIGHT:-1080}" \
-            --output-bootdisk "${BOOTDISK:=/home/arch/OSX-KVM/OpenCore/OpenCore.qcow2}" \
+            --output-bootdisk "${BOOTDISK:=/home/arch/Docker-OSX/OSX-KVM/OpenCore/OpenCore.qcow2}" \
             --output-env "${ENV:=/env}" \
     || exit 1 ; } \
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
@@ -247,7 +247,7 @@ CMD echo "${BOILERPLATE}" \
             --mac-address "${MAC_ADDRESS}" \
             --width "${WIDTH:-1920}" \
             --height "${HEIGHT:-1080}" \
-            --output-bootdisk "${BOOTDISK:=/home/arch/OSX-KVM/OpenCore/OpenCore.qcow2}"  \
+            --output-bootdisk "${BOOTDISK:=/home/arch/Docker-OSX/OSX-KVM/OpenCore/OpenCore.qcow2}"  \
     || exit 1 ; } \
     ; { [[ "${DISPLAY}" = ':99' ]] || [[ "${HEADLESS}" == true ]] ; } && { \
         nohup Xvfb :99 -screen 0 1920x1080x16 \

--- a/Dockerfile.naked
+++ b/Dockerfile.naked
@@ -38,7 +38,7 @@ USER root
 
 WORKDIR /root
 
-RUN rm -f /home/arch/OSX-KVM/mac_hdd_ng.img
+RUN rm -f /home/arch/Docker-OSX/OSX-KVM/mac_hdd_ng.img
 
 # OPTIONAL: Arch Linux server mirrors for super fast builds
 # set RANKMIRRORS to any value other that nothing, e.g. -e RANKMIRRORS=true
@@ -103,7 +103,7 @@ RUN sudo pacman -Syy \
 ####
 
 
-WORKDIR /home/arch/OSX-KVM
+WORKDIR /home/arch/Docker-OSX/OSX-KVM
 
 RUN mkdir -p ~/.ssh \
     && touch ~/.ssh/authorized_keys \
@@ -118,7 +118,7 @@ RUN mkdir -p ~/.ssh \
 ####
 
 # symlink the old directory, for redundancy
-RUN ln -s /home/arch/OSX-KVM/OpenCore /home/arch/OSX-KVM/OpenCore-Catalina || true
+RUN ln -s /home/arch/Docker-OSX/OSX-KVM/OpenCore /home/arch/Docker-OSX/OSX-KVM/OpenCore-Catalina || true
 
 ####
 
@@ -180,9 +180,9 @@ CMD sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" 2>/dev/n
     ; } \
     ; [[ "${NOPICKER}" == true ]] && { \
         sed -i '/^.*InstallMedia.*/d' Launch.sh \
-        && export BOOTDISK="${BOOTDISK:=/home/arch/OSX-KVM/OpenCore/OpenCore-nopicker.qcow2}" \
+        && export BOOTDISK="${BOOTDISK:=/home/arch/Docker-OSX/OSX-KVM/OpenCore/OpenCore-nopicker.qcow2}" \
     ; } \
-    || export BOOTDISK="${BOOTDISK:=/home/arch/OSX-KVM/OpenCore/OpenCore.qcow2}" \
+    || export BOOTDISK="${BOOTDISK:=/home/arch/Docker-OSX/OSX-KVM/OpenCore/OpenCore.qcow2}" \
     ; [[ "${GENERATE_UNIQUE}" == true ]] && { \
         ./Docker-OSX/osx-serial-generator/generate-unique-machine-values.sh \
             --master-plist-url="${MASTER_PLIST_URL}" \
@@ -191,7 +191,7 @@ CMD sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" 2>/dev/n
             --bootdisks \
             --width "${WIDTH:-1920}" \
             --height "${HEIGHT:-1080}" \
-            --output-bootdisk "${BOOTDISK:=/home/arch/OSX-KVM/OpenCore/OpenCore.qcow2}" \
+            --output-bootdisk "${BOOTDISK:=/home/arch/Docker-OSX/OSX-KVM/OpenCore/OpenCore.qcow2}" \
             --output-env "${ENV:=/env}" \
     || exit 1 ; } \
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
@@ -205,6 +205,6 @@ CMD sudo touch /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" 2>/dev/n
             --mac-address "${MAC_ADDRESS}" \
             --width "${WIDTH:-1920}" \
             --height "${HEIGHT:-1080}" \
-            --output-bootdisk "${BOOTDISK:=/home/arch/OSX-KVM/OpenCore/OpenCore.qcow2}" \
+            --output-bootdisk "${BOOTDISK:=/home/arch/Docker-OSX/OSX-KVM/OpenCore/OpenCore.qcow2}" \
     || exit 1 ; } \
     ; ./enable-ssh.sh && /bin/bash -c ./Launch.sh

--- a/Dockerfile.naked-auto
+++ b/Dockerfile.naked-auto
@@ -24,7 +24,7 @@ USER root
 
 WORKDIR /root
 
-RUN rm -f /home/arch/OSX-KVM/mac_hdd_ng.img
+RUN rm -f /home/arch/Docker-OSX/OSX-KVM/mac_hdd_ng.img
 
 # For taking screenshots of the Xfvb screen, useful during development.
 ARG SCROT
@@ -100,7 +100,7 @@ RUN sudo pacman -Syy \
 ####
 
 
-WORKDIR /home/arch/OSX-KVM
+WORKDIR /home/arch/Docker-OSX/OSX-KVM
 
 RUN mkdir -p ~/.ssh \
     && touch ~/.ssh/authorized_keys \
@@ -125,14 +125,14 @@ ARG IMAGE_URL=
 
 RUN if [[ "${COMPLETE}" ]]; then \
         echo "Downloading your image... This step might take a while... Press Ctrl+C if you want to abort." \
-        ; rm -f /home/arch/OSX-KVM/mac_hdd_ng.img \
-        && wget ${WGET_OPTIONS} -O /home/arch/OSX-KVM/mac_hdd_ng.img "${IMAGE_URL}" \
+        ; rm -f /home/arch/Docker-OSX/OSX-KVM/mac_hdd_ng.img \
+        && wget ${WGET_OPTIONS} -O /home/arch/Docker-OSX/OSX-KVM/mac_hdd_ng.img "${IMAGE_URL}" \
     ; fi
 
 ####
 
 # symlink the old directory, for redundancy
-RUN ln -s /home/arch/OSX-KVM/OpenCore /home/arch/OSX-KVM/OpenCore-Catalina || true
+RUN ln -s /home/arch/Docker-OSX/OSX-KVM/OpenCore /home/arch/Docker-OSX/OSX-KVM/OpenCore-Catalina || true
 
 ####
 
@@ -201,9 +201,9 @@ CMD echo "${BOILERPLATE}" \
     ; sudo chown -R $(id -u):$(id -g) /dev/kvm /dev/snd "${IMAGE_PATH}" "${BOOTDISK}" "${ENV}" 2>/dev/null || true \
     ; [[ "${NOPICKER}" == true ]] && { \
         sed -i '/^.*InstallMedia.*/d' Launch.sh \
-        && export BOOTDISK="${BOOTDISK:=/home/arch/OSX-KVM/OpenCore/OpenCore-nopicker.qcow2}" \
+        && export BOOTDISK="${BOOTDISK:=/home/arch/Docker-OSX/OSX-KVM/OpenCore/OpenCore-nopicker.qcow2}" \
     ; } \
-    || export BOOTDISK="${BOOTDISK:=/home/arch/OSX-KVM/OpenCore/OpenCore.qcow2}" \
+    || export BOOTDISK="${BOOTDISK:=/home/arch/Docker-OSX/OSX-KVM/OpenCore/OpenCore.qcow2}" \
     ; [[ "${GENERATE_UNIQUE}" == true ]] && { \
         ./Docker-OSX/osx-serial-generator/generate-unique-machine-values.sh \
             --master-plist-url="${MASTER_PLIST_URL}" \
@@ -212,7 +212,7 @@ CMD echo "${BOILERPLATE}" \
             --bootdisks \
             --width "${WIDTH:-1920}" \
             --height "${HEIGHT:-1080}" \
-            --output-bootdisk "${BOOTDISK:=/home/arch/OSX-KVM/OpenCore/OpenCore.qcow2}" \
+            --output-bootdisk "${BOOTDISK:=/home/arch/Docker-OSX/OSX-KVM/OpenCore/OpenCore.qcow2}" \
             --output-env "${ENV:=/env}" \
     || exit 1 ; } \
     ; [[ "${GENERATE_SPECIFIC}" == true ]] && { \
@@ -226,7 +226,7 @@ CMD echo "${BOILERPLATE}" \
             --mac-address "${MAC_ADDRESS}" \
             --width "${WIDTH:-1920}" \
             --height "${HEIGHT:-1080}" \
-            --output-bootdisk "${BOOTDISK:=/home/arch/OSX-KVM/OpenCore/OpenCore.qcow2}" \
+            --output-bootdisk "${BOOTDISK:=/home/arch/Docker-OSX/OSX-KVM/OpenCore/OpenCore.qcow2}" \
     || exit 1 ; } \
     ; { [[ "${DISPLAY}" = ':99' ]] || [[ "${HEADLESS}" == true ]] ; } && { \
         nohup Xvfb :99 -screen 0 1920x1080x16 \

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ First time here? try [initial setup](#initial-setup), otherwise try the instruct
 ### Catalina [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/latest?label=sickcodes%2Fdocker-osx%3Alatest](https://img.shields.io/docker/image-size/sickcodes/docker-osx/latest?label=sickcodes%2Fdocker-osx%3Alatest)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
 
 ```bash
-qemu-img create -f qcow2 image.img
+qemu-img create -f qcow2 image.img 512G
 
 docker run -it \
     --device /dev/kvm \
@@ -73,7 +73,7 @@ docker run -it \
 ### Big Sur [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/big-sur?label=sickcodes%2Fdocker-osx%3Abig-sur](https://img.shields.io/docker/image-size/sickcodes/docker-osx/big-sur?label=sickcodes%2Fdocker-osx%3Abig-sur)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
 
 ```bash
-qemu-img create -f qcow2 image.img
+qemu-img create -f qcow2 image.img 512G
 
 docker run -it \
     --device /dev/kvm \
@@ -90,7 +90,7 @@ docker run -it \
 ### Monterey [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/monterey?label=sickcodes%2Fdocker-osx%3Amonterey](https://img.shields.io/docker/image-size/sickcodes/docker-osx/monterey?label=sickcodes%2Fdocker-osx%3Amonterey)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
 
 ```bash
-qemu-img create -f qcow2 image.img
+qemu-img create -f qcow2 image.img 512G
 
 docker run -it \
     --device /dev/kvm \
@@ -129,7 +129,7 @@ docker run -it \
 ### High Sierra [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/high-sierra?label=sickcodes%2Fdocker-osx%3Ahigh-sierra](https://img.shields.io/docker/image-size/sickcodes/docker-osx/high-sierra?label=sickcodes%2Fdocker-osx%3Ahigh-sierra)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
 
 ```bash
-qemu-img create -f qcow2 image.img
+qemu-img create -f qcow2 image.img 512G
 
 docker run -it \
     --device /dev/kvm \
@@ -145,7 +145,7 @@ docker run -it \
 ### Mojave [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/mojave?label=sickcodes%2Fdocker-osx%3Amojave](https://img.shields.io/docker/image-size/sickcodes/docker-osx/mojave?label=sickcodes%2Fdocker-osx%3Amojave)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
 
 ```bash
-qemu-img create -f qcow2 image.img
+qemu-img create -f qcow2 image.img 512G
 
 docker run -it \
     --device /dev/kvm \

--- a/README.md
+++ b/README.md
@@ -57,31 +57,40 @@ First time here? try [initial setup](#initial-setup), otherwise try the instruct
 ### Catalina [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/latest?label=sickcodes%2Fdocker-osx%3Alatest](https://img.shields.io/docker/image-size/sickcodes/docker-osx/latest?label=sickcodes%2Fdocker-osx%3Alatest)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
 
 ```bash
+qemu-img create -f qcow2 image.img
+
 docker run -it \
     --device /dev/kvm \
     -p 50922:10022 \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     -e "DISPLAY=${DISPLAY:-:0.0}" \
+    -v "${PWD}/image.img:/image" \
     sickcodes/docker-osx:latest
 
 # docker build -t docker-osx .
+# if you want to keep everything inside the container, remove "${PWD}/image.img:/image" which will tell the Dockerfile to use the image at /image
 ```
 ### Big Sur [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/big-sur?label=sickcodes%2Fdocker-osx%3Abig-sur](https://img.shields.io/docker/image-size/sickcodes/docker-osx/big-sur?label=sickcodes%2Fdocker-osx%3Abig-sur)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
 
 ```bash
+qemu-img create -f qcow2 image.img
+
 docker run -it \
     --device /dev/kvm \
     -p 50922:10022 \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     -e "DISPLAY=${DISPLAY:-:0.0}" \
+    -v "${PWD}/image.img:/image" \
     sickcodes/docker-osx:big-sur
 
 # docker build -t docker-osx --build-arg SHORTNAME=big-sur .
+# if you want to keep everything inside the container, remove "${PWD}/image.img:/image" which will tell the Dockerfile to use the image at /image
 ```
 
 ### Monterey [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/monterey?label=sickcodes%2Fdocker-osx%3Amonterey](https://img.shields.io/docker/image-size/sickcodes/docker-osx/monterey?label=sickcodes%2Fdocker-osx%3Amonterey)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
 
 ```bash
+qemu-img create -f qcow2 image.img
 
 docker run -it \
     --device /dev/kvm \
@@ -90,6 +99,7 @@ docker run -it \
     -e "DISPLAY=${DISPLAY:-:0.0}" \
     -e GENERATE_UNIQUE=true \
     -e MASTER_PLIST_URL='https://raw.githubusercontent.com/sickcodes/osx-serial-generator/master/config-custom.plist' \
+    -v "${PWD}/image.img:/image" \
     sickcodes/docker-osx:monterey
 
 # docker build -t docker-osx --build-arg SHORTNAME=monterey .
@@ -119,12 +129,14 @@ docker run -it \
 ### High Sierra [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/high-sierra?label=sickcodes%2Fdocker-osx%3Ahigh-sierra](https://img.shields.io/docker/image-size/sickcodes/docker-osx/high-sierra?label=sickcodes%2Fdocker-osx%3Ahigh-sierra)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
 
 ```bash
+qemu-img create -f qcow2 image.img
 
 docker run -it \
     --device /dev/kvm \
     -p 50922:10022 \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     -e "DISPLAY=${DISPLAY:-:0.0}" \
+    -v "${PWD}/image.img:/image" \
     sickcodes/docker-osx:high-sierra
 
 # docker build -t docker-osx --build-arg SHORTNAME=high-sierra .
@@ -133,12 +145,14 @@ docker run -it \
 ### Mojave [![https://img.shields.io/docker/image-size/sickcodes/docker-osx/mojave?label=sickcodes%2Fdocker-osx%3Amojave](https://img.shields.io/docker/image-size/sickcodes/docker-osx/mojave?label=sickcodes%2Fdocker-osx%3Amojave)](https://hub.docker.com/r/sickcodes/docker-osx/tags?page=1&ordering=last_updated)
 
 ```bash
+qemu-img create -f qcow2 image.img
 
 docker run -it \
     --device /dev/kvm \
     -p 50922:10022 \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     -e "DISPLAY=${DISPLAY:-:0.0}" \
+    -v "${PWD}/image.img:/image" \
     sickcodes/docker-osx:mojave
 
 # docker build -t docker-osx --build-arg SHORTNAME=mojave .


### PR DESCRIPTION
- Move `/home/arch/OSX-KVM` to `/home/arch/Docker-OSX/OSX-KVM`, but symlink it anyway

- If you put an image at /imamge, the image will use that at runtime.

- Move OSX-KVM to submodule, and symlink for perfect redundancy `ln -s /home/arch/Docker-OSX/OSX-KVM /home/arch/OSX-KVM`