### PR TITLE
Add VNC_PASSWORD env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -175,7 +175,7 @@ RUN touch Launch.sh \
     && tee -a Launch.sh <<< '[[ "${RAM}" = max ]] && export RAM="$(("$(head -n1 /proc/meminfo | tr -dc "[:digit:]") / 1000000"))"' \
     && tee -a Launch.sh <<< '[[ "${RAM}" = half ]] && export RAM="$(("$(head -n1 /proc/meminfo | tr -dc "[:digit:]") / 2000000"))"' \
     && tee -a Launch.sh <<< 'sudo chown -R $(id -u):$(id -g) /dev/snd 2>/dev/null || true' \
-    && tee -a Launch.sh <<< 'exec qemu-system-x86_64 -m ${RAM:-4}000 \' \
+    && tee -a Launch.sh <<< '(test "${VNC_PASSWORD+x}" && printf "change vnc password\n%s\n" $VNC_PASSWORD) | exec qemu-system-x86_64 -m ${RAM:-4}000 \' \
     && tee -a Launch.sh <<< '-cpu ${CPU:-Penryn},${CPUID_FLAGS:-vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check,}${BOOT_ARGS} \' \
     && tee -a Launch.sh <<< '-machine q35,${KVM-"accel=kvm:tcg"} \' \
     && tee -a Launch.sh <<< '-smp ${CPU_STRING:-${SMP:-4},cores=${CORES:-4}} \' \


### PR DESCRIPTION
This will make it easy to set the vnc password using an environment variable.

Related issues:
https://github.com/sickcodes/Docker-OSX/issues/341
https://github.com/sickcodes/Docker-OSX/issues/229