### PR TITLE
sshpass install and label

### DIFF
--- a/Dockerfile.auto
+++ b/Dockerfile.auto
@@ -42,7 +42,7 @@
 
 FROM sickcodes/docker-osx:latest
 
-MAINTAINER 'https://twitter.com/sickcodes' <https://sick.codes>
+LABEL maintainer='https://twitter.com/sickcodes <https://sick.codes>'
 
 USER root
 
@@ -71,7 +71,7 @@ RUN if [[ "${RANKMIRRORS}" ]]; then \
     ; fi \
     ; yes | pacman -Scc
 
-RUN pacman -Syu xorg-server-xvfb wget xterm xorg-xhost xorg-xrandr sshpass --noconfirm \
+RUN pacman -Syu xorg-server-xvfb wget xterm xorg-xhost xorg-xrandr --noconfirm \
     && if [[ "${SCROT}" ]]; then \
         pacman -Syu scrot base-devel --noconfirm \
         && git clone --recurse-submodules --depth 1 https://github.com/stolk/imcat.git \
@@ -87,6 +87,9 @@ RUN pacman -Syu xorg-server-xvfb wget xterm xorg-xhost xorg-xrandr sshpass --noc
         && chmod +x /usr/bin/scrotcat \
     ; fi \
     ; yes | pacman -Scc
+
+RUN pacman -S sshpass --noconfirm \
+    && yes | pacman -Scc
 
 USER arch
 

--- a/Dockerfile.monterey
+++ b/Dockerfile.monterey
@@ -21,7 +21,7 @@
 
 FROM sickcodes/docker-osx
 
-MAINTAINER 'https://twitter.com/sickcodes' <https://sick.codes>
+LABEL maintainer='https://twitter.com/sickcodes <https://sick.codes>'
 
 SHELL ["/bin/bash", "-c"]
 

--- a/Dockerfile.naked
+++ b/Dockerfile.naked
@@ -32,7 +32,7 @@
 
 FROM sickcodes/docker-osx:latest
 
-MAINTAINER 'https://twitter.com/sickcodes' <https://sick.codes>
+LABEL maintainer='https://twitter.com/sickcodes <https://sick.codes>'
 
 USER root
 

--- a/Dockerfile.naked-auto
+++ b/Dockerfile.naked-auto
@@ -18,7 +18,7 @@
 
 FROM sickcodes/docker-osx:latest
 
-MAINTAINER 'https://twitter.com/sickcodes' <https://sick.codes>
+LABEL maintainer='https://twitter.com/sickcodes <https://sick.codes>'
 
 USER root
 
@@ -52,7 +52,7 @@ RUN if [[ "${RANKMIRRORS}" ]]; then \
 # For taking screenshots of the Xfvb screen, useful during development.
 ARG SCROT
 
-RUN pacman -Syu xorg-server-xvfb wget xterm xorg-xhost xorg-xrandr sshpass --noconfirm \
+RUN pacman -Syu xorg-server-xvfb wget xterm xorg-xhost xorg-xrandr --noconfirm \
     && if [[ "${SCROT}" ]]; then \
         pacman -Syu scrot base-devel --noconfirm \
         && git clone --recurse-submodules --depth 1 https://github.com/stolk/imcat.git \
@@ -68,6 +68,9 @@ RUN pacman -Syu xorg-server-xvfb wget xterm xorg-xhost xorg-xrandr sshpass --noc
         && chmod +x /usr/bin/scrotcat \
     ; fi \
     ; yes | pacman -Scc
+
+RUN pacman -S sshpass --noconfirm \
+    && yes | pacman -Scc
 
 USER arch
 


### PR DESCRIPTION
Fix the installation of sshpass for the issue #506.

Remove deprecated `MAINTAINER` in favor `LABEL maintainer=`.