### PR TITLE
Fix issue with invalid GPG keys in VNC version

### DIFF
--- a/vnc-version/Dockerfile
+++ b/vnc-version/Dockerfile
@@ -93,6 +93,9 @@ RUN if [[ "${RANKMIRRORS}" ]]; then { pacman -Sy wget --noconfirm || pacman -Syu
     && tee -a /etc/pacman.d/mirrorlist <<< 'Server = https://mirror.rackspace.com/archlinux/$repo/os/$arch' \
     && cat /etc/pacman.d/mirrorlist ; fi
 
+# Fixes issue with invalid GPG keys: update the archlinux-keyring package to get the latest keys, then remove and regenerate gnupg keys
+RUN pacman -Sy archlinux-keyring --noconfirm && rm -rf /etc/pacman.d/gnupg && pacman-key --init && pacman-key --populate
+
 USER arch
 
 RUN yes | sudo pacman -Syyuu --noconfirm \


### PR DESCRIPTION
Without this, `pacman` gives the following errors when trying to update packages as part of the installation:
* The first error is `error: pambase: key "991F6E3F0765CF6295888586139B09DA5BF0D338" is unknown`
* This is followed by a bunch of errors similar to (but with different filenames): `:: File /var/cache/pacman/pkg/pambase-20221020-1-any.pkg.tar.zst is corrupted (invalid or corrupted package (PGP signature)). Do you want to delete it? [Y/n]`
* These are followed by `error: libvpx: key "95220BE99CE6FF778AE0DC670F65C7D881506130" is unknown`
* Finally, it ends with `error: failed to commit transaction (invalid or corrupted package)` and `Errors occurred, no packages were upgraded.` before exiting with code `1`.

This `RUN` command will update the `archlinux-keyring` package to get the latest keys, then remove and regenerate all gnupg keys inside the container. This allows `pacman` to accept the GPG keys and resolves the above error.