### PR TITLE
replace invalid wireshark manufacturer database link in unique generator

### DIFF
--- a/custom/generate-unique-machine-values.sh
+++ b/custom/generate-unique-machine-values.sh
@@ -222,7 +222,7 @@ build_mac_serial () {
 
 download_vendor_mac_addresses () {
     # download the MAC Address vendor list
-    [ -e "${MAC_ADDRESSES_FILE:=vendor_macs.tsv}" ] || wget -O "${MAC_ADDRESSES_FILE}" https://gitlab.com/wireshark/wireshark/-/raw/master/manuf
+    [ -e "${MAC_ADDRESSES_FILE:=vendor_macs.tsv}" ] || wget -O "${MAC_ADDRESSES_FILE}" https://www.wireshark.org/download/automated/data/manuf
 }
 
 download_qcow_efi_folder () {


### PR DESCRIPTION
relates to https://github.com/sickcodes/Docker-OSX/issues/681

The manufacturer list currently referenced by the machine value generator script no longer exists resulting in a 404 and no unique device identifiers generated.

That manufacturer list is now populating automatically at the address in this change (see [this issue](https://ask.wireshark.org/question/32122/wireshark-manufacturer-database-on-gitlab-is-broken/) for more details).

Tested by running

```sh
./custom/generate-unique-machine-values.sh
```

from this branch.