### PR TITLE
Fix manuf file link in custom folder

### DIFF
--- a/custom/generate-unique-machine-values.sh
+++ b/custom/generate-unique-machine-values.sh
@@ -222,7 +222,7 @@ build_mac_serial () {
 
 download_vendor_mac_addresses () {
     # download the MAC Address vendor list
-    [ -e "${MAC_ADDRESSES_FILE:=vendor_macs.tsv}" ] || wget -O "${MAC_ADDRESSES_FILE}" https://gitlab.com/wireshark/wireshark/-/raw/master/manuf
+    [ -e "${MAC_ADDRESSES_FILE:=vendor_macs.tsv}" ] || wget -O "${MAC_ADDRESSES_FILE}" https://gitlab.com/wireshark/wireshark/-/raw/release-3.6/manuf
 }
 
 download_qcow_efi_folder () {


### PR DESCRIPTION
The Wireshark manuf file link currently leads to a 404 page on the Wireshark gitlab. Proposed fix: change manuf file link to https://gitlab.com/wireshark/wireshark/-/raw/release-3.6/manuf, the last release where the manuf file was available from Gitlab.