### PR TITLE
Fix LegacyKeyValueFormat Docker warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -235,7 +235,7 @@ RUN grep -v InstallMedia ./Launch.sh > ./Launch-nopicker.sh \
 
 USER arch
 
-ENV USER arch
+ENV USER=arch
 
 # These are hardcoded serials for non-iMessage related research
 # Overwritten by using GENERATE_UNIQUE=true


### PR DESCRIPTION
When doing `docker build`, docker (tested with 27.0.3) prints a warning:

    LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 238)

This commit fixes it by using proper syntax.